### PR TITLE
add notary ingress option support

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -27,6 +27,7 @@ spec:
         backend:
           serviceName: {{ template "harbor.fullname" . }}-ui
           servicePort: 80
+  {{ if .Values.notary.enabled }}
   - host: "{{ template "harbor.notaryFQDN" . }}"
     http:
       paths:
@@ -34,4 +35,5 @@ spec:
         backend:
           serviceName: {{ template "harbor.notaryServiceName" . }}
           servicePort: 4443
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
如果我设置了 notary.enabled=false ，ingress 会创建这个不存在的 service ，添加这个属性的可选。

``` bash

# 创建 nfs / local / cloud 存储

helm install \
--name="registry" \
--set="externalDomain=registry.clelo.org" \
--set="notary.enabled=false" \
.

```

会创建一个  notary-registry.clelo.org 的域名。


Signed-off-by: MingLe Lan lanmingle@qq.com

