### PR TITLE
Using Deployment rather than StatefulSet for adminserver, registry and chartmuseum

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `adminserver.image.tag` | Tag for adminserver image | `dev` |
 | `adminserver.image.pullPolicy` | Pull Policy for adminserver image | `IfNotPresent` |
 | `adminserver.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
-| `adminserver.volumes` | used to create PVCs if persistence is enabled (see instructions in values.yaml) | see values.yaml |
 | `adminserver.nodeSelector` | Node labels for pod assignment | `{}` |
 | `adminserver.tolerations` | Tolerations for pod assignment | `[]` |
 | `adminserver.affinity` | Node/Pod affinities | `{}` |

--- a/templates/adminserver/adminserver-dpl.yaml
+++ b/templates/adminserver/adminserver-dpl.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1beta2
-kind: StatefulSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-adminserver"
   labels:
@@ -7,7 +7,6 @@ metadata:
     component: adminserver
 spec:
   replicas: 1
-  serviceName: "{{ template "harbor.fullname" . }}-adminserver"
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
@@ -39,16 +38,10 @@ spec:
         ports:
         - containerPort: 8080
         volumeMounts:
-        - name: adminserver-config
-          mountPath: /etc/adminserver/config
         - name: adminserver-key
           mountPath: /etc/adminserver/key
           subPath: key
       volumes:
-      {{- if not .Values.persistence.enabled }}
-      - name: adminserver-config
-        emptyDir: {}
-      {{- end }}
       - name: adminserver-key
         secret:
           secretName: "{{ template "harbor.fullname" . }}-adminserver"
@@ -67,20 +60,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-  {{- if .Values.persistence.enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: adminserver-config
-    spec:
-      accessModes: [{{ .Values.adminserver.volumes.config.accessMode | quote }}]
-      {{- if .Values.adminserver.volumes.config.storageClass }}
-      {{- if (eq "-" .Values.adminserver.volumes.config.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: "{{ .Values.adminserver.volumes.config.storageClass }}"
-      {{- end }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.adminserver.volumes.config.size | quote }}
-  {{- end -}}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.chartmuseum.enabled }}
-apiVersion: apps/v1beta2
-kind: StatefulSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-chartmuseum"
   labels:
@@ -8,7 +8,6 @@ metadata:
     component: chartmuseum
 spec:
   replicas: 1
-  serviceName: "{{ template "harbor.fullname" . }}-chartmuseum"
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
@@ -33,11 +32,15 @@ spec:
         ports:
         - containerPort: 9999
         # TODO: update it after moving the storage out of registry scope
-        {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
+      {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
         volumeMounts:
         - name: chartmuseum-data
           mountPath: /chart_storage
-        {{- end }}
+      volumes:
+      - name: chartmuseum-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.chartmuseum.volumes.data.existingClaim | default (printf "%s-chartmuseum" (include "harbor.fullname" .)) }}
+      {{- end }}
       {{- with .Values.chartmuseum.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -50,23 +53,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
-  {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
-  volumeClaimTemplates:
-  - metadata:
-      name: chartmuseum-data
-      labels:
-{{ include "harbor.labels" . | indent 8 }}
-    spec:
-      accessModes: [{{ .Values.chartmuseum.volumes.data.accessMode | quote }}]
-      {{- if .Values.chartmuseum.volumes.data.storageClass }}
-      {{- if (eq "-" .Values.chartmuseum.volumes.data.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: "{{ .Values.chartmuseum.volumes.data.storageClass }}"
-      {{- end }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.chartmuseum.volumes.data.size | quote }}
-  {{- end -}}
 {{- end }}

--- a/templates/chartmuseum/chartmuseum-pvc.yaml
+++ b/templates/chartmuseum/chartmuseum-pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.chartmuseum.volumes.data.existingClaim }}
+{{- if eq .Values.registry.storage.type "filesystem" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "harbor.fullname" . }}-chartmuseum
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: chartmuseum
+spec:
+  accessModes: 
+    - {{ .Values.chartmuseum.volumes.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.chartmuseum.volumes.data.size }}
+  {{- if .Values.chartmuseum.volumes.data.storageClass }}
+    {{- if eq "-" .Values.chartmuseum.volumes.data.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ .Values.chartmuseum.volumes.data.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1beta2
-kind: StatefulSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-registry"
   labels:
@@ -7,7 +7,6 @@ metadata:
     component: registry
 spec:
   replicas: 1
-  serviceName: "{{ template "harbor.fullname" . }}-registry"
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
@@ -102,6 +101,11 @@ spec:
       - name: registry-config
         configMap:
           name: "{{ template "harbor.fullname" . }}-registry"
+      {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
+      - name: registry-data
+        persistentVolumeClaim:
+          claimName: {{ .Values.registry.volumes.data.existingClaim | default (printf "%s-registry" (include "harbor.fullname" .)) }}  
+      {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -114,22 +118,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-  {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
-  volumeClaimTemplates:
-  - metadata:
-      name: registry-data
-      labels:
-{{ include "harbor.labels" . | indent 8 }}
-    spec:
-      accessModes: [{{ .Values.registry.volumes.data.accessMode | quote }}]
-      {{- if .Values.registry.volumes.data.storageClass }}
-      {{- if (eq "-" .Values.registry.volumes.data.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: "{{ .Values.registry.volumes.data.storageClass }}"
-      {{- end }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.registry.volumes.data.size | quote }}
-  {{- end }}

--- a/templates/registry/registry-pvc.yaml
+++ b/templates/registry/registry-pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.registry.volumes.data.existingClaim }}
+{{- if eq .Values.registry.storage.type "filesystem" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "harbor.fullname" . }}-registry
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: registry
+spec:
+  accessModes: 
+    - {{ .Values.registry.volumes.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.registry.volumes.data.size }}
+  {{- if .Values.registry.volumes.data.storageClass }}
+    {{- if eq "-" .Values.registry.volumes.data.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ .Values.registry.volumes.data.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -55,11 +55,6 @@ adminserver:
     repository: goharbor/harbor-adminserver
     tag: *harbor_image_tag
     pullPolicy: IfNotPresent
-  volumes:
-    config:
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
-      size: 1Gi
   # resources:
   #  requests:
   #    memory: 256Mi
@@ -203,6 +198,7 @@ registry:
   ## Persist data to a persistent volume
   volumes:
     data:
+      # existingClaim: ""
       # storageClass: "-"
       accessMode: ReadWriteOnce
       size: 5Gi
@@ -222,6 +218,7 @@ chartmuseum:
     pullPolicy: IfNotPresent
   volumes:
     data:
+      # existingClaim: ""
       # storageClass: "-"
       accessMode: ReadWriteOnce
       size: 5Gi
@@ -239,11 +236,6 @@ clair:
     repository: goharbor/clair-photon
     tag: dev
     pullPolicy: IfNotPresent
-  volumes:
-    pgData:
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
-      size: 1Gi
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
The components: adminserver, registry and chartmuseum are all stateless applications, so the Deployment should be used in the chart.

Signed-off-by: Wenkai Yin <yinw@vmware.com>