### PR TITLE
Separate the ingress rule host and "externalDomain" in values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,10 @@ This [Helm](https://github.com/kubernetes/helm) chart installs [Harbor](https://
 
 - Kubernetes cluster 1.8+ with Beta APIs enabled
 - Kubernetes Ingress Controller is enabled
-- Helm CLI 2.8.0+
+- Helm 2.8.0+
 
-## Setup a Kubernetes cluster
-
-You can use any tools to setup a K8s cluster.
-In this guide, we use [minikube](https://github.com/kubernetes/minikube) 0.25.0 to setup a K8s cluster as the dev/test env.
-```bash
-# Start minikube
-minikube start --vm-driver=none
-# Enable Ingress Controller
-minikube addons enable ingress
-```
 ## Installing the Chart
 
-First install [Helm CLI](https://github.com/kubernetes/helm#install), then initialize Helm.
-```bash
-helm init
-```
 Download Harbor helm chart code.
 ```bash
 git clone https://github.com/goharbor/harbor-helm
@@ -37,10 +23,8 @@ helm dependency update
 ```
 Install the Harbor helm chart with a release name `my-release`:
 ```bash
-helm install --debug --name my-release --set externalDomain=harbor.my.domain,externalPort=443 .
+helm install --name my-release .
 ```
-**Note:** Make sure `harbor.my.domain` can be resolved to the K8s Ingress Controller IP on the machines where you run docker or access Harbor UI.
-You can add `harbor.my.domain` and IP mapping in the DNS server, or in /etc/hosts, or use the FQDN `harbor.<IP>.xip.io`.
 
 The command deploys Harbor on the Kubernetes cluster with the default configuration.
 The [configuration](#configuration) section lists the parameters that can be configured in values.yaml or via '--set' flag during installation.
@@ -50,7 +34,7 @@ The [configuration](#configuration) section lists the parameters that can be con
 To uninstall/delete the `my-release` deployment:
 
 ```bash
-helm delete my-release
+helm delete --purge my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -63,9 +47,7 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | -----------------------    | ---------------------------------- | ----------------------- |
 | **Harbor** |
 | `persistence.enabled`     | Persistent data | `true` |
-| `externalProtocol`     | The protocol Harbor serves with | `https` |
-| `externalDomain`       | Harbor will run on (https://`externalDomain`/). Recommend using K8s Ingress Controller FQDN as `externalDomain`, or make sure this FQDN resolves to the K8s Ingress Controller IP. | `harbor.my.domain` |
-| `externalPort`     | The external port Harbor serves on. Configure it with the port of Ingress controller if it is enabled | `32700` |
+| `externalURL`       | Ther external URL for Harbor core service | `https://core.harbor.domain` |
 | `harborAdminPassword`  | The password of system admin | `Harbor12345` |
 | `authenticationMode` | The authentication mode: `db_auth` for local database, `ldap_auth` for LDAP | `db_auth` |
 | `selfRegistration`               | Allows users to register by themselves, otherwise only system administrators can add users | `on` |
@@ -90,6 +72,10 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `harborImageTag` | The tag of Harbor images | `dev` |
 | **Ingress** |
 | `ingress.enabled` | Enable ingress objects | `true` |
+| `ingress.hosts.core` | The host of Harbor core service in ingress rule | `core.harbor.domain` |
+| `ingress.hosts.notary` | The host of Harbor notary service in ingress rule | `notary.harbor.domain` |
+| `ingress.annotations` | The annotations used in ingress | `true` |
+| `ingress.tls.enabled` | Enable TLS | `true` |
 | `ingress.tls.secretName` | Fill the secretName if you want to use the certificate of yourself when Harbor serves with HTTPS. A certificate will be generated automatically by the chart if leave it empty | |
 | **Adminserver** |
 | `adminserver.image.repository` | Repository for adminserver image | `goharbor/harbor-adminserver` |

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Please wait for several minutes for Harbor deployment to complete.
-Then you should be able to visit the UI portal at {{ template "harbor.externalURL" . }}. 
+Then you should be able to visit the UI portal at {{ .Values.externalURL }}. 
 For more details, please visit https://github.com/goharbor/harbor.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -30,28 +30,12 @@ release: {{ .Release.Name }}
 app: "{{ template "harbor.name" . }}"
 {{- end -}}
 
-{{- define "harbor.externalURL" -}}
-{{- if .Values.externalPort -}}
-{{- printf "%s://%s:%s" .Values.externalProtocol .Values.externalDomain (toString .Values.externalPort) -}}
-{{- else -}}
-{{- printf "%s://%s" .Values.externalProtocol .Values.externalDomain -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Use *.domain.com as the Common Name in the certificate,
-so it can match Harbor service FQDN and Notary service FQDN.
-*/}}
-{{- define "harbor.certCommonName" -}}
-{{- $list := splitList "." .Values.externalDomain -}}
-{{- $list := prepend (rest $list) "*" -}}
-{{- $cn := join "." $list -}}
-{{- printf "%s" $cn -}}
-{{- end -}}
-
-{{/* The external FQDN of Notary server. */}}
-{{- define "harbor.notaryFQDN" -}}
-{{- printf "notary-%s" .Values.externalDomain -}}
+{{- define "harbor.isAutoGenedCertNeeded" -}}
+  {{- if and (and .Values.ingress.enabled .Values.ingress.tls.enabled) (not .Values.ingress.tls.secretName) -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "harbor.notaryServiceName" -}}

--- a/templates/adminserver/adminserver-cm.yaml
+++ b/templates/adminserver/adminserver-cm.yaml
@@ -17,7 +17,7 @@ data:
   EMAIL_FROM: "{{ .Values.email.from }}"
   EMAIL_IDENTITY: "{{ .Values.email.identity }}"
   EMAIL_INSECURE: "{{ .Values.email.insecure }}"
-  EXT_ENDPOINT: "{{ template "harbor.externalURL" . }}"
+  EXT_ENDPOINT: "{{ .Values.externalURL }}"
   UI_URL: "http://{{ template "harbor.fullname" . }}-ui"
   JOBSERVICE_URL: "http://{{ template "harbor.fullname" . }}-jobservice"
   REGISTRY_URL: "http://{{ template "harbor.fullname" . }}-registry:5000"

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ingress.enabled }}
+{{- if .Values.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -8,32 +8,29 @@ metadata:
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 spec:
-{{ if eq .Values.externalProtocol "https" }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
-  - hosts:
-    - "{{ .Values.externalDomain }}"
-    - "{{ template "harbor.notaryFQDN" . }}"
-    {{ if eq .Values.ingress.tls.secretName "" }}
-    secretName: "{{ template "harbor.fullname" . }}-ingress"
-    {{ else }}
-    secretName: {{ .Values.ingress.tls.secretName }}
-    {{ end }}
-{{ end }}
+  {{- if .Values.ingress.tls.secretName }}
+  - secretName: {{ .Values.ingress.tls.secretName }}
+  {{- else }}
+  - secretName: "{{ template "harbor.fullname" . }}-ingress"
+  {{- end }}
+  {{- end }}
   rules:
-  - host: "{{ .Values.externalDomain }}"
+  - host: {{ .Values.ingress.hosts.core }}
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ template "harbor.fullname" . }}-ui
           servicePort: 80
-  {{ if .Values.notary.enabled }}
-  - host: "{{ template "harbor.notaryFQDN" . }}"
+  {{- if .Values.notary.enabled }}
+  - host: {{ .Values.ingress.hosts.notary }}
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ template "harbor.notaryServiceName" . }}
           servicePort: 4443
-  {{ end }}
-{{ end }}
+  {{- end }}
+{{- end }}

--- a/templates/ingress/secret.yaml
+++ b/templates/ingress/secret.yaml
@@ -1,8 +1,6 @@
-{{ if eq .Values.externalProtocol "https" }}
-{{ if .Values.ingress.enabled }}
-{{ if eq .Values.ingress.tls.secretName "" }}
-{{ $ca := genCA "harbor-ca" 3650 }}
-{{ $cert := genSignedCert (include "harbor.certCommonName" .) nil nil 3650 $ca }}
+{{- if eq (include "harbor.isAutoGenedCertNeeded" .) "true" }}
+{{- $ca := genCA "harbor-ca" 3650 }}
+{{- $cert := genSignedCert .Values.ingress.hosts.core nil (list .Values.ingress.hosts.core .Values.ingress.hosts.notary) 3650 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,9 +9,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.tlsCrt | default $cert.Cert | b64enc | quote }}
-  tls.key: {{ .Values.tlsKey | default $cert.Key | b64enc | quote }}
-  ca.crt: {{ .Values.caCrt | default $ca.Cert | b64enc | quote }}
-{{ end }}
-{{ end }}
-{{ end }}
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}

--- a/templates/notary/notary-cm.yaml
+++ b/templates/notary/notary-cm.yaml
@@ -37,7 +37,7 @@ data:
       "auth": {
           "type": "token",
           "options": {
-              "realm": "{{ template "harbor.externalURL" . }}/service/token",
+              "realm": "{{ .Values.externalURL }}/service/token",
               "service": "harbor-notary",
               "issuer": "harbor-token-issuer",
               "rootcertbundle": "/root.crt"

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -149,7 +149,7 @@ data:
     auth:
       token:
         issuer: harbor-token-issuer
-        realm: "{{ template "harbor.externalURL" . }}/service/token"
+        realm: "{{ .Values.externalURL }}/service/token"
         rootcertbundle: /etc/registry/root.crt
         service: harbor-registry
     notifications:

--- a/templates/ui/ui-dpl.yaml
+++ b/templates/ui/ui-dpl.yaml
@@ -54,14 +54,10 @@ spec:
         - name: ui-secrets-private-key
           mountPath: /etc/ui/private_key.pem
           subPath: tokenServicePrivateKey
-        {{- if eq .Values.externalProtocol "https" }}
-        {{- if .Values.ingress.enabled }}
-        {{- if eq .Values.ingress.tls.secretName "" }}
+        {{- if eq (include "harbor.isAutoGenedCertNeeded" .) "true" }}
         - name: ca-download
           mountPath: /etc/ui/ca/ca.crt
           subPath: ca.crt
-        {{- end }}
-        {{- end }}
         {{- end }}
         - name: psc
           mountPath: /etc/ui/token
@@ -78,17 +74,13 @@ spec:
       - name: ui-secrets-private-key
         secret:
           secretName: "{{ template "harbor.fullname" . }}-ui"
-      {{- if eq .Values.externalProtocol "https" }}
-      {{- if .Values.ingress.enabled }}
-      {{- if eq .Values.ingress.tls.secretName "" }}
+      {{- if eq (include "harbor.isAutoGenedCertNeeded" .) "true" }}
       - name: ca-download
         secret:
           secretName: "{{ template "harbor.fullname" . }}-ingress"
           items:
             - key: ca.crt
               path: ca.crt
-      {{- end }}
-      {{- end }}
       {{- end }}
       - name: psc
         emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -1,11 +1,32 @@
 persistence:
   enabled: true
-externalProtocol: https
-# The FQDN for Harbor service
-externalDomain: harbor.my.domain
-# The Port for Harbor service, leave empty if the service 
-# is to be bound to port 80/443
-externalPort: 32700
+# Ther external URL for Harbor core service. It is used to
+# 1) populate the docker/helm commands showed on portal
+# 2) populate the token service URL returned to docker/notary client
+# 
+# Format: protocol://domain[:port]
+# Usually, if ingress is enabled, the domain should be the value of
+# ingress.hosts.core .
+# If Harbor is deployed behind the proxy, set it as the URL of proxy
+externalURL: https://core.harbor.domain
+
+ingress:
+  enabled: true
+  hosts:
+    core: core.harbor.domain
+    notary: notary.harbor.domain
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  tls:
+    enabled: true
+    # Fill the secretName if you want to use the certificate of 
+    # yourself when Harbor serves with HTTPS. A certificate will 
+    # be generated automatically by the chart if leave it empty
+    secretName: ""
+
 harborAdminPassword: Harbor12345
 authenticationMode: "db_auth"
 selfRegistration: "on"
@@ -31,21 +52,6 @@ email:
 
 # The secret key used for encryption. Must be a string of 16 chars.
 secretKey: not-a-secure-key
-
-# These annotations allow the registry to work behind the nginx
-# ingress controller.
-ingress:
-  enabled: true
-  annotations:
-    ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-  tls:
-    # Fill the secretName if you want to use the certificate of 
-    # yourself when Harbor serves with HTTPS. A certificate will 
-    # be generated automatically by the chart if leave it empty
-    secretName: ""
 
 # The tag for Harbor docker images.
 harborImageTag: &harbor_image_tag dev


### PR DESCRIPTION
The externalDomain is used to generate the ingress rule, but in the scenario that another proxy is deployed before Harbor, the externalDomain should be configured as the domain of external proxy and it should not be used to generate the ingress rule.

Signed-off-by: Wenkai Yin <yinw@vmware.com>