### PR TITLE
Make Clair updater interval configurable in chart

### DIFF
--- a/templates/clair/clair-cm.yaml
+++ b/templates/clair/clair-cm.yaml
@@ -25,7 +25,7 @@ data:
         # Deadline before an API request will respond with a 503
         timeout: 300s
       updater:
-        interval: 12h
+        interval: {{ .Values.clair.updatersInterval }}h
 
       notifier:
         attempts: 3

--- a/values.yaml
+++ b/values.yaml
@@ -236,6 +236,9 @@ clair:
     repository: goharbor/clair-photon
     tag: dev
     pullPolicy: IfNotPresent
+  # The interval of clair updaters, the unit is hour, 
+  # set to 0 to disable the updaters
+  updatersInterval: 12
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
Users can set the values of clair.updatersInterval in values.yaml to configure the updater interval

Signed-off-by: Wenkai Yin <yinw@vmware.com>