### PR TITLE
Add hosts in tls of ingress

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
+  - hosts:
+    - {{ .Values.ingress.hosts.core }}
+    - {{ .Values.ingress.hosts.notary }}
   {{- if .Values.ingress.tls.secretName }}
   - secretName: {{ .Values.ingress.tls.secretName }}
   {{- else }}


### PR DESCRIPTION
The "hosts" is needed in some old versions of nginx ingress controller

Signed-off-by: Wenkai Yin <yinw@vmware.com>