### PR TITLE
Fix syntax error in ingress

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -13,11 +13,11 @@ spec:
   - hosts:
     - {{ .Values.ingress.hosts.core }}
     - {{ .Values.ingress.hosts.notary }}
-  {{- if .Values.ingress.tls.secretName }}
-  - secretName: {{ .Values.ingress.tls.secretName }}
-  {{- else }}
-  - secretName: "{{ template "harbor.fullname" . }}-ingress"
-  {{- end }}
+    {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+    {{- else }}
+    secretName: "{{ template "harbor.fullname" . }}-ingress"
+    {{- end }}
   {{- end }}
   rules:
   - host: {{ .Values.ingress.hosts.core }}


### PR DESCRIPTION
The "secretName" should be the property of the item tls item

Signed-off-by: Wenkai Yin <yinw@vmware.com>