### PR TITLE
Template database init container image

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
       - name: "remove-lost-found"
-        image: "busybox:1.25.0"
+        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         command: ["rm", "-Rf", "/var/lib/postgresql/data/lost+found"]
         volumeMounts:
         - name: database-data


### PR DESCRIPTION
* Allows for disconnected/offline installs

Cannot currently install harbor from an offline harbor repository without access to pull upstream container 'busybox:1.25.0' (or pre-caching same on hosts)

* Removes dependency on static busybox version

'busybox:1.25.0' is a two year old image with published vulnerabilities resolve in newer versions.  Image should be templated and either default to an existing harbor container to reduce attack surface, or updated to default to a newer busybox.

* Reuses existing harbor database container by default

As init container is only executing `rm`, the existing database image should suffice for the init container, reducing the number of required images.