### PR TITLE
Add registry controller to the chart

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -150,11 +150,35 @@ postgres://{{ template "harbor.database.username" . }}:{{ template "harbor.datab
   {{- end -}}
 {{- end -}}
 
-{{- define "harbor.redis.databaseIndex" -}}
+{{- define "harbor.redis.coreDatabaseIndex" -}}
   {{- if .Values.redis.external.enabled -}}
-    {{- .Values.redis.external.databaseIndex -}}
+    {{- .Values.redis.external.coreDatabaseIndex -}}
   {{- else -}}
     {{- printf "%s" "0" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.redis.jobserviceDatabaseIndex" -}}
+  {{- if .Values.redis.external.enabled -}}
+    {{- .Values.redis.external.jobserviceDatabaseIndex -}}
+  {{- else -}}
+    {{- printf "%s" "1" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.redis.registryDatabaseIndex" -}}
+  {{- if .Values.redis.external.enabled -}}
+    {{- .Values.redis.external.registryDatabaseIndex -}}
+  {{- else -}}
+    {{- printf "%s" "2" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.redis.chartmuseumDatabaseIndex" -}}
+  {{- if .Values.redis.external.enabled -}}
+    {{- .Values.redis.external.chartmuseumDatabaseIndex -}}
+  {{- else -}}
+    {{- printf "%s" "3" }}
   {{- end -}}
 {{- end -}}
 
@@ -169,11 +193,22 @@ postgres://{{ template "harbor.database.username" . }}:{{ template "harbor.datab
 {{/*the username redis is used for a placeholder as no username needed in redis*/}}
 {{- define "harbor.redisForJobservice" -}}
   {{- if and .Values.redis.external.enabled .Values.redis.external.usePassword -}}
-    redis:{{ template "harbor.redis.password" . }}@{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}/{{ template "harbor.redis.databaseIndex" }}
+    {{- printf "redis://redis:%s@%s:%s/%s" (include "harbor.redis.password" . ) (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.jobserviceDatabaseIndex" . ) }}
   {{- else if and (not .Values.redis.external.enabled) .Values.redis.usePassword -}}
-    redis:{{ template "harbor.redis.password" . }}@{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}/{{ template "harbor.redis.databaseIndex" }}
+    {{- printf "redis://redis:%s@%s:%s/%s" (include "harbor.redis.password" . ) (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.jobserviceDatabaseIndex" . ) }}
   {{- else }}
-    {{- template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}/{{ template "harbor.redis.databaseIndex" }}
+    {{- template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}/{{ template "harbor.redis.jobserviceDatabaseIndex" . }}
+  {{- end -}}
+{{- end -}}
+
+{{/*the username redis is used for a placeholder as no username needed in redis*/}}
+{{- define "harbor.redisForGC" -}}
+  {{- if and .Values.redis.external.enabled .Values.redis.external.usePassword -}}
+    {{- printf "redis://redis:%s@%s:%s/%s" (include "harbor.redis.password" . ) (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.registryDatabaseIndex" . ) }}
+  {{- else if and (not .Values.redis.external.enabled) .Values.redis.usePassword -}}
+    {{- printf "redis://redis:%s@%s:%s/%s" (include "harbor.redis.password" . ) (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.registryDatabaseIndex" . ) }}
+  {{- else }}
+    {{- printf "redis://%s:%s/%s" (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.registryDatabaseIndex" . ) -}}
   {{- end -}}
 {{- end -}}
 

--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -9,7 +9,7 @@ data:
   PORT: "9999"
   CACHE: "redis"
   CACHE_REDIS_ADDR: "{{ template "harbor.redis.host" }}:{{ template "harbor.redis.port" }}"
-  CACHE_REDIS_DB: "{{ template "harbor.redis.databaseIndex" }}"
+  CACHE_REDIS_DB: "{{ template "harbor.redis.chartmuseumDatabaseIndex" }}"
   BASIC_AUTH_USER: "chart_controller"
   DEPTH: "1"
   STORAGE: "local"

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -34,6 +34,10 @@ spec:
               secretKeyRef:
                 name: "{{ template "harbor.fullname" . }}-jobservice"
                 key: secret
+          - name: ADMINSERVER_URL
+            value: "http://{{ template "harbor.fullname" . }}-adminserver"
+          - name: REGISTRY_CONTROLLER_URL
+            value: "http://{{ template "harbor.fullname" . }}-registry:8080"
           - name: LOG_LEVEL
             value: debug
           - name: GODEBUG

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -139,7 +139,7 @@ data:
     redis:
       addr: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
       password: {{ template "harbor.redis.password" . }}
-      db: {{ template "harbor.redis.databaseIndex" . }}
+      db: {{ template "harbor.redis.registryDatabaseIndex" . }}
     http:
       addr: :5000
       # set via environment variable
@@ -160,3 +160,8 @@ data:
           timeout: 3000ms
           threshold: 5
           backoff: 1s
+  ctl-config.yml: |+
+    ---
+    protocol: "http"
+    port: 8080
+    log_level: "INFO"

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: {{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag }}
+        image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.registry.resources | indent 10 }}
@@ -94,6 +94,36 @@ spec:
         - name: registry-config
           mountPath: /etc/registry/config.yml
           subPath: config.yml
+      - name: registryctl
+        image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.registry.resources | indent 10 }}
+        args: ["serve", "/etc/registry/config.yml"]
+        env:
+          - name: UI_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-ui"
+                key: secret
+          - name: JOBSERVICE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-jobservice"
+                key: secret
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        {{- if and .Values.persistence.enabled (eq .Values.registry.storage.type "filesystem") }}
+        - name: registry-data
+          mountPath: {{ .Values.registry.storage.filesystem.rootdirectory }}
+        {{- end }}
+        - name: registry-config
+          mountPath: /etc/registry/config.yml
+          subPath: config.yml
+        - name: registry-config
+          mountPath: /etc/registryctl/config.yml
+          subPath: ctl-config.yml
       volumes:
       - name: registry-root-certificate
         secret:

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -6,7 +6,10 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - port: 5000
+    - name: registry
+      port: 5000
+    - name: controller
+      port: 8080
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
     component: registry

--- a/templates/ui/ui-dpl.yaml
+++ b/templates/ui/ui-dpl.yaml
@@ -30,6 +30,8 @@ spec:
                 key: secret
           - name: _REDIS_URL
             value: {{ template "harbor.redisForUI" . }}
+          - name: _REDIS_URL_REG
+            value: {{ template "harbor.redisForGC" . }}
           - name: GODEBUG
             value: netdns=cgo
           - name: LOG_LEVEL

--- a/values.yaml
+++ b/values.yaml
@@ -121,11 +121,16 @@ database:
     sslmode: "disable"
 
 registry:
-  image:
-    repository: goharbor/registry-photon
-    tag: dev
+  registry:
+    image:
+      repository: goharbor/registry-photon
+      tag: dev
+    logLevel: info
+  controller:
+    image:
+      repository: goharbor/harbor-registryctl
+      tag: dev
   replicas: 1
-  logLevel: info
   storage:
     # specify the type of storage: "filesystem", "azure", "gcs", "s3", "swift", 
     # "oss" and fill the information needed in the corresponding section
@@ -255,13 +260,21 @@ redis:
       accessMode: ReadWriteOnce
       size: 1Gi
     nodeSelector: {}
+    # Overwrite the default value in the Redis chart
+    # as the command "FLUSHDB" is needed for online GC
+    disableCommands: ""
   persistence:
     # existingClaim:
   external:
     enabled: false
     host: "192.168.0.2"
     port: "6379"
-    databaseIndex: "0"
+    # The "coreDatabaseIndex" must be "0" as the library Harbor
+    # used doesn't support configuring it
+    coreDatabaseIndex: "0"
+    jobserviceDatabaseIndex: "1"
+    registryDatabaseIndex: "2"
+    chartmuseumDatabaseIndex: "3"
     usePassword: false
     password: "changeit"
 


### PR DESCRIPTION
The registry controller is used to run online garbage collection, this commit adds it into the chart

Signed-off-by: Wenkai Yin <yinw@vmware.com>