### PR TITLE
Keep only a single image pull policy for all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ helm install --name my-release .
 ```
 
 The command deploys Harbor on the Kubernetes cluster with the default configuration.
-The [configuration](#configuration) section lists the parameters that can be configured in values.yaml or via '--set' flag during installation.
+The [configuration](#configuration) section lists the parameters that can be configured in values.yaml or via `--set` flag during installation.
+
+**Notes:** If you want to disble the persistence by `--set`, two items need to be configured as `false`: `persistence.enabled` and `redis.master.persistence.enabled`.
 
 ## Uninstalling the Chart
 
@@ -67,7 +69,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | **Adminserver** |
 | `adminserver.image.repository` | Repository for adminserver image | `goharbor/harbor-adminserver` |
 | `adminserver.image.tag` | Tag for adminserver image | `dev` |
-| `adminserver.image.pullPolicy` | Pull Policy for adminserver image | `IfNotPresent` |
 | `adminserver.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `adminserver.nodeSelector` | Node labels for pod assignment | `{}` |
 | `adminserver.tolerations` | Tolerations for pod assignment | `[]` |
@@ -75,7 +76,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | **Jobservice** |
 | `jobservice.image.repository` | Repository for jobservice image | `goharbor/harbor-jobservice` |
 | `jobservice.image.tag` | Tag for jobservice image | `dev` |
-| `jobservice.image.pullPolicy` | Pull Policy for jobservice image | `IfNotPresent` |
 | `jobservice.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `jobservice.nodeSelector` | Node labels for pod assignment | `{}` |
 | `jobservice.tolerations` | Tolerations for pod assignment | `[]` |
@@ -83,7 +83,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | **UI** |
 | `ui.image.repository` | Repository for ui image | `goharbor/harbor-ui` |
 | `ui.image.tag` | Tag for ui image | `dev` |
-| `ui.image.pullPolicy` | Pull Policy for ui image | `IfNotPresent` |
 | `ui.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `ui.nodeSelector` | Node labels for pod assignment | `{}` |
 | `ui.tolerations` | Tolerations for pod assignment | `[]` |
@@ -92,7 +91,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `database.type` | If external database is used, set it to `external` | `internal` |
 | `database.internal.image.repository` | Repository for database image | `goharbor/harbor-db` |
 | `database.internal.image.tag` | Tag for database image | `dev` |
-| `database.internal.image.pullPolicy` | Pull Policy for database image | `IfNotPresent` |
 | `database.internal.password` | The password for database | `changeit` |
 | `database.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `database.internal.volumes` | The volume used to persistent data |
@@ -111,7 +109,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | **Registry** |
 | `registry.image.repository` | Repository for registry image | `goharbor/registry-photon` |
 | `registry.image.tag` | Tag for registry image | `dev` |
-| `registry.image.pullPolicy` | Pull Policy for registry image | `IfNotPresent` |
 | `registry.logLevel` | The log level | `info` |
 | `registry.storage.type` | The storage used to store images: `filesystem`, `azure`, `gcs`, `s3`, `swift`, `oss` | `filesystem` |
 | `registry.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
@@ -123,7 +120,6 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `chartmuseum.enabled` | Enable chartmusuem to store chart | `true` |
 | `chartmuseum.image.repository` | Repository for chartmuseum image | `goharbor/chartmuseum-photon` |
 | `chartmuseum.image.tag` | Tag for chartmuseum image | `dev` |
-| `chartmuseum.image.pullPolicy` | Pull Policy for chartmuseum image | `IfNotPresent` |
 | `chartmuseum.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `chartmuseum.volumes` | used to create PVCs if persistence is enabled (see instructions in values.yaml) | see values.yaml |
 | `chartmuseum.nodeSelector` | Node labels for pod assignment | `{}` |

--- a/templates/adminserver/adminserver-dpl.yaml
+++ b/templates/adminserver/adminserver-dpl.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: adminserver
         image: "{{ .Values.adminserver.image.repository }}:{{ .Values.adminserver.image.tag }}"
-        imagePullPolicy: "{{ .Values.adminserver.image.pullPolicy }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         resources:
 {{ toYaml .Values.adminserver.resources | indent 10 }}
         envFrom:

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: chartmuseum
         image: {{ .Values.chartmuseum.image.repository }}:{{ .Values.chartmuseum.image.tag }}
-        imagePullPolicy: {{ .Values.chartmuseum.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.chartmuseum.resources | indent 10 }}
         envFrom:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: clair
         image: {{ .Values.clair.image.repository }}:{{ .Values.clair.image.tag }}
-        imagePullPolicy: {{ .Values.clair.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         args: ["-insecure-tls", "-config", "/etc/clair/config.yaml"]
         resources:
 {{ toYaml .Values.clair.resources | indent 10 }}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: database
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
-        imagePullPolicy: {{ .Values.database.internal.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.database.internal.resources | indent 10 }}
         envFrom:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: jobservice
         image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
-        imagePullPolicy: {{ .Values.jobservice.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.jobservice.resources | indent 10 }}
         env:

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: notary-server
         image: {{ .Values.notary.server.image.repository }}:{{ .Values.notary.server.image.tag }}
-        imagePullPolicy: {{ .Values.notary.server.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.notary.server.resources | indent 10 }}
         env:

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: notary-signer
         image: {{ .Values.notary.signer.image.repository }}:{{ .Values.notary.signer.image.tag }}
-        imagePullPolicy: {{ .Values.notary.signer.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.notary.signer.resources | indent 10 }}
         env:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: portal
         image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}
-        imagePullPolicy: {{ .Values.portal.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
         - containerPort: 80
     {{- with .Values.ui.nodeSelector }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: registry
         image: {{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag }}
-        imagePullPolicy: {{ .Values.registry.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.registry.resources | indent 10 }}
         args: ["serve", "/etc/registry/config.yml"]

--- a/templates/ui/ui-dpl.yaml
+++ b/templates/ui/ui-dpl.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: ui
         image: {{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}
-        imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
           - name: UI_SECRET
             valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -31,13 +31,12 @@ harborAdminPassword: Harbor12345
 # The secret key used for encryption. Must be a string of 16 chars.
 secretKey: not-a-secure-key
 
-imagePullPolicy: &image_pull_policy IfNotPresent
+imagePullPolicy: IfNotPresent
 
 portal:
   image:
     repository: goharbor/harbor-portal
     tag: dev
-    pullPolicy: *image_pull_policy
 # resources:
 #  requests:
 #    memory: 256Mi
@@ -50,7 +49,6 @@ adminserver:
   image:
     repository: goharbor/harbor-adminserver
     tag: dev
-    pullPolicy: *image_pull_policy
   # resources:
   #  requests:
   #    memory: 256Mi
@@ -63,7 +61,6 @@ jobservice:
   image:
     repository: goharbor/harbor-jobservice
     tag: dev
-    pullPolicy: *image_pull_policy
   maxWorkers: 50
 # resources:
 #   requests:
@@ -77,7 +74,6 @@ ui:
   image:
     repository: goharbor/harbor-ui
     tag: dev
-    pullPolicy: *image_pull_policy
 # resources:
 #  requests:
 #    memory: 256Mi
@@ -95,7 +91,6 @@ database:
     image:
       repository: goharbor/harbor-db
       tag: dev
-      pullPolicy: *image_pull_policy
     # the superuser password of database
     password: "changeit"
     volumes:
@@ -125,7 +120,6 @@ registry:
   image:
     repository: goharbor/registry-photon
     tag: dev
-    pullPolicy: *image_pull_policy
   logLevel: info
   storage:
     # specify the type of storage: "filesystem", "azure", "gcs", "s3", "swift", 
@@ -209,7 +203,6 @@ chartmuseum:
   image:
     repository: goharbor/chartmuseum-photon
     tag: dev
-    pullPolicy: *image_pull_policy
   volumes:
     data:
       # existingClaim: ""
@@ -229,7 +222,6 @@ clair:
   image:
     repository: goharbor/clair-photon
     tag: dev
-    pullPolicy: *image_pull_policy
   # The interval of clair updaters, the unit is hour, 
   # set to 0 to disable the updaters
   updatersInterval: 12
@@ -271,12 +263,10 @@ notary:
     image:
       repository: goharbor/notary-server-photon
       tag: dev
-      pullPolicy: *image_pull_policy
   signer:
     image:
       repository: goharbor/notary-signer-photon
       tag: dev
-      pullPolicy: *image_pull_policy
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
The yaml anchor can not work as expected when setting values by "helm --set", so remove the anchor and keep only one global key to set the image pull policy

Signed-off-by: Wenkai Yin <yinw@vmware.com>