### PR TITLE
Create separate ingress resource for notary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `ingress.hosts.notary` | The host of Harbor notary service in ingress rule | `notary.harbor.domain` |
 | `ingress.annotations` | The annotations used in ingress | `true` |
 | `ingress.tls.enabled` | Enable TLS | `true` |
-| `ingress.tls.secretName` | Fill the secretName if you want to use the certificate of yourself when Harbor serves with HTTPS. A certificate will be generated automatically by the chart if leave it empty | |
+| `ingress.tls.secretName` | Fill the secretName if you want to use the certificate of yourself when Harbor serves with HTTPS. A certificate will be generated automatically by the chart if leave it empty |
+| `ingress.tls.notarySecretName` | Fill the notarySecretName if you want to use the certificate of yourself when Notary serves with HTTPS. if left empty, it uses the `ingress.tls.secretName` value |
 | **Portal** |
 | `portal.image.repository` | Repository for portal image | `goharbor/harbor-portal` |
 | `portal.image.tag` | Tag for portal image | `dev` |

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -12,9 +12,15 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.hosts.core }}
-    - {{ .Values.ingress.hosts.notary }}
     {{- if .Values.ingress.tls.secretName }}
     secretName: {{ .Values.ingress.tls.secretName }}
+    {{- else }}
+    secretName: "{{ template "harbor.fullname" . }}-ingress"
+    {{- end }}
+  - hosts:
+    - {{ .Values.ingress.hosts.notary }}
+    {{- if .Values.ingress.tls.notarySecretName }}
+    secretName: {{ .Values.ingress.tls.notarySecretName }}
     {{- else }}
     secretName: "{{ template "harbor.fullname" . }}-ingress"
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -22,10 +22,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   tls:
     enabled: true
-    # Fill the secretName if you want to use the certificate of 
-    # yourself when Harbor serves with HTTPS. A certificate will 
-    # be generated automatically by the chart if leave it empty
-    secretName: ""
+    # Fill in the empty string if you want to use your own TLS secret
+    secretName: &tls_secretName ""
+    # notary secret by default uses the value of secretName
+    # replace the variable reference if you want to use your own TLS secret for notary
+    notarySecretName: *tls_secretName
 
 harborAdminPassword: Harbor12345
 # The secret key used for encryption. Must be a string of 16 chars.


### PR DESCRIPTION
Currently this helm chart only creates one ingress resource and shares the same TLS secret. 
This splits the two services into their own ingress resource and allows users to use a different secret.

To expect the same behavior, the default is to use the same value as what is set in `ingress.tls.secretName`