### PR TITLE
Add PVC to jobservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `jobservice.image.repository` | Repository for jobservice image | `goharbor/harbor-jobservice` |
 | `jobservice.image.tag` | Tag for jobservice image | `dev` |
 | `jobservice.replicas` | The replica count | `1` |
+| `jobservice.volumes` | The volume used to store data if persistence is enabled | |
 | `jobservice.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `jobservice.nodeSelector` | Node labels for pod assignment | `{}` |
 | `jobservice.tolerations` | Tolerations for pod assignment | `[]` |
@@ -118,10 +119,12 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `database.external.notaryServerDatabase` | The database used by Notary server | `notary_server` |
 | `database.external.notarySignerDatabase` | The database used by Notary signer | `notary_signer` |
 | **Registry** |
-| `registry.image.repository` | Repository for registry image | `goharbor/registry-photon` |
-| `registry.image.tag` | Tag for registry image | `dev` |
+| `registry.registry.image.repository` | Repository for registry image | `goharbor/registry-photon` |
+| `registry.registry.image.tag` | Tag for registry image | `dev` |
+| `registry.registry.logLevel` | The log level | `info` |
+| `registry.controller.image.repository` | Repository for registry controller image | `goharbor/harbor-registryctl` |
+| `registry.controller.image.tag` | Tag for registry controller image | `dev` |
 | `registry.replicas` | The replica count | `1` |
-| `registry.logLevel` | The log level | `info` |
 | `registry.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `registry.volumes` | used to create PVCs if persistence is enabled (see instructions in values.yaml) | see values.yaml |
 | `registry.nodeSelector` | Node labels for pod assignment | `{}` |

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -55,7 +55,12 @@ spec:
         configMap:
           name: "{{ template "harbor.fullname" . }}-jobservice"
       - name: job-logs
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.jobservice.volumes.data.existingClaim | default (printf "%s-jobservice" (include "harbor.fullname" .)) }}  
+        {{- else }}
         emptyDir: {}
+        {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/jobservice/jobservice-pvc.yaml
+++ b/templates/jobservice/jobservice-pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.enabled (not .Values.jobservice.volumes.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "harbor.fullname" . }}-jobservice
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: jobservice
+spec:
+  accessModes: 
+    - {{ .Values.jobservice.volumes.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.jobservice.volumes.data.size }}
+  {{- if .Values.jobservice.volumes.data.storageClass }}
+    {{- if eq "-" .Values.jobservice.volumes.data.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ .Values.jobservice.volumes.data.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,12 @@ jobservice:
     tag: dev
   replicas: 1
   maxWorkers: 50
+  volumes:
+    data:
+      # existingClaim: ""
+      # storageClass: "-"
+      accessMode: ReadWriteOnce
+      size: 1Gi
 # resources:
 #   requests:
 #     memory: 256Mi


### PR DESCRIPTION
Currently, the logs of jobservice are stored in an emptyDir volume, this commit adds a PVC for it

Signed-off-by: Wenkai Yin <yinw@vmware.com>