### PR TITLE
Remove the dependency chart for Redis and use the one of Harbor own

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ Checkout the branch.
 cd harbor-helm
 git checkout branch_name
 ```
-Download external dependent charts required by Harbor chart.
-```bash
-helm dependency update
-```
 Install the Harbor helm chart with a release name `my-release`:
 ```bash
 helm install --name my-release .
@@ -34,8 +30,6 @@ helm install --name my-release .
 
 The command deploys Harbor on the Kubernetes cluster with the default configuration.
 The [configuration](#configuration) section lists the parameters that can be configured in values.yaml or via `--set` flag during installation.
-
-**Notes:** If you want to disble the persistence by `--set`, two items need to be configured as `false`: `persistence.enabled` and `redis.master.persistence.enabled`.
 
 ## Uninstalling the Chart
 
@@ -105,7 +99,7 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `database.internal.image.repository` | Repository for database image | `goharbor/harbor-db` |
 | `database.internal.image.tag` | Tag for database image | `dev` |
 | `database.internal.password` | The password for database | `changeit` |
-| `database.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
+| `database.internal.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `database.internal.volumes` | The volume used to persistent data |
 | `database.internal.nodeSelector` | Node labels for pod assignment | `{}` |
 | `database.internal.tolerations` | Tolerations for pod assignment | `[]` |
@@ -154,16 +148,21 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `clair.tolerations` | Tolerations for pod assignment | `[]` |
 | `clair.affinity` | Node/Pod affinities | `{}` |
 | **Redis** |
-| `redis.usePassword` | Whether use password | `false` |
-| `redis.password` | The password for Redis | `changeit` |
-| `redis.cluster.enabled` | Enable Redis cluster | `false` |
-| `redis.master.persistence.enabled` | Persistent data   | `true` |
-| `redis.external.enabled` | If an external Redis is used, set it to `true` | `false` |
+| `redis.type` | If external redis is used, set it to `external` | `internal` |
+| `redis.internal.image.repository` | Repository for redis image | `goharbor/redis-photon` |
+| `redis.internal.image.tag` | Tag for redis image | `dev` |
+| `redis.internal.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
+| `redis.internal.volumes` | The volume used to persistent data |
+| `redis.internal.nodeSelector` | Node labels for pod assignment | `{}` |
+| `redis.internal.tolerations` | Tolerations for pod assignment | `[]` |
+| `redis.internal.affinity` | Node/Pod affinities | `{}` |
 | `redis.external.host` | The hostname of external Redis | `192.168.0.2` |
 | `redis.external.port` | The port of external Redis | `6379` |
-| `redis.external.databaseIndex` | The database index of external Redis | `0` |
-| `redis.external.usePassword` | Whether use password for external Redis | `false` |
-| `redis.external.password` | The password of external Redis | `changeit` |
+| `redis.external.coreDatabaseIndex` | The database index for core | `0` |
+| `redis.external.jobserviceDatabaseIndex` | The database index for jobservice | `1` |
+| `redis.external.registryDatabaseIndex` | The database index for registry | `2` |
+| `redis.external.chartmuseumDatabaseIndex` | The database index for chartmuseum | `3` |
+| `redis.external.password` | The password of external Redis | |
 | **Notary** |
 | `notary.enabled` | Enable Notary? | `true` |
 | `notary.server.image.repository` | Repository for notary server image | `goharbor/notary-server-photon` |

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: redis
-  version: 3.2.5
-  repository: https://kubernetes-charts.storage.googleapis.com

--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -8,8 +8,8 @@ metadata:
 data:
   PORT: "9999"
   CACHE: "redis"
-  CACHE_REDIS_ADDR: "{{ template "harbor.redis.host" }}:{{ template "harbor.redis.port" }}"
-  CACHE_REDIS_DB: "{{ template "harbor.redis.chartmuseumDatabaseIndex" }}"
+  CACHE_REDIS_ADDR: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
+  CACHE_REDIS_DB: "{{ template "harbor.redis.chartmuseumDatabaseIndex" . }}"
   BASIC_AUTH_USER: "chart_controller"
   DEPTH: "1"
   DEBUG: "false"

--- a/templates/chartmuseum/chartmuseum-secret.yaml
+++ b/templates/chartmuseum/chartmuseum-secret.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  CACHE_REDIS_PASSWORD: "{{ template "harbor.redis.password" }}"
+  CACHE_REDIS_PASSWORD: {{ include "harbor.redis.rawPassword" . | b64enc | quote }}
 {{- $storage := .Values.storage }}
 {{- $storageType := $storage.type }}
 {{- if eq $storageType "azure" }}

--- a/templates/redis/service.yaml
+++ b/templates/redis/service.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.redis.type "internal" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "harbor.redis" . }}
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+spec:
+  ports:
+    - port: 6379
+  selector:
+{{ include "harbor.matchLabels" . | indent 4 }}
+    component: redis
+{{- end -}}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -1,0 +1,72 @@
+{{- if eq .Values.redis.type "internal" -}}
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ template "harbor.redis" . }}
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: redis
+spec:
+  replicas: 1
+  serviceName: {{ template "harbor.redis" . }}
+  selector:
+    matchLabels:
+{{ include "harbor.matchLabels" . | indent 6 }}
+      component: redis
+  template:
+    metadata:
+      labels:
+{{ include "harbor.labels" . | indent 8 }}
+        component: redis
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.redis.internal.image.repository }}:{{ .Values.redis.internal.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.redis.internal.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/redis
+      {{- if not .Values.persistence.enabled }}
+      volumes:
+      - name: data
+        emptyDir: {}
+      {{- else if .Values.redis.internal.volumes.data.existingClaim }}
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Values.redis.internal.volumes.data.existingClaim }}
+      {{- end -}}
+    {{- with .Values.redis.internal.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.redis.internal.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.redis.internal.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+  {{- if and .Values.persistence.enabled (not .Values.redis.internal.volumes.data.existingClaim) }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+{{ include "harbor.labels" . | indent 8 }}
+    spec:
+      accessModes: [{{ .Values.redis.internal.volumes.data.accessMode | quote }}]
+      {{- if .Values.redis.internal.volumes.data.storageClass }}
+      {{- if (eq "-" .Values.redis.internal.volumes.data.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.redis.internal.volumes.data.storageClass }}"
+      {{- end }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.redis.internal.volumes.data.size | quote }}
+  {{- end -}}
+  {{- end -}}

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -138,7 +138,7 @@ data:
         enabled: true
     redis:
       addr: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
-      password: {{ template "harbor.redis.password" . }}
+      password: {{ template "harbor.redis.rawPassword" . }}
       db: {{ template "harbor.redis.registryDatabaseIndex" . }}
     http:
       addr: :5000

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 persistence:
-  enabled: &persistence_enabled true
+  enabled: true
 # Ther external URL for Harbor core service. It is used to
 # 1) populate the docker/helm commands showed on portal
 # 2) populate the token service URL returned to docker/notary client
@@ -93,7 +93,6 @@ core:
   tolerations: []
   affinity: {}
 
-# TODO: change the style to be same with redis
 database:
   # if external database is used, set "type" to "external"
   # and fill the connection informations in "external" section
@@ -258,27 +257,27 @@ clair:
   affinity: {}
 
 redis:
-  # if external Redis is used, set "external.enabled" to "true"
-  # and fill the connection informations in "external" section.
-  # or the internal Redis will be used
-  usePassword: false
-  password: "changeit"
-  cluster:
-    enabled: false
-  master:
-    persistence:
-      enabled: *persistence_enabled
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
-      size: 1Gi
+  # if external Redis is used, set "type" to "external"
+  # and fill the connection informations in "external" section
+  type: internal
+  internal:
+    image:
+      repository: goharbor/redis-photon
+      tag: dev
+    volumes:
+      data:
+        # existingClaim: ""
+        # storageClass: "-"
+        accessMode: ReadWriteOnce
+        size: 1Gi
+    # resources:
+    #  requests:
+    #    memory: 256Mi
+    #    cpu: 100m
     nodeSelector: {}
-    # Overwrite the default value in the Redis chart
-    # as the command "FLUSHDB" is needed for online GC
-    disableCommands: ""
-  persistence:
-    # existingClaim:
+    tolerations: []
+    affinity: {}
   external:
-    enabled: false
     host: "192.168.0.2"
     port: "6379"
     # The "coreDatabaseIndex" must be "0" as the library Harbor
@@ -287,8 +286,7 @@ redis:
     jobserviceDatabaseIndex: "1"
     registryDatabaseIndex: "2"
     chartmuseumDatabaseIndex: "3"
-    usePassword: false
-    password: "changeit"
+    password: ""
 
 notary:
   enabled: true


### PR DESCRIPTION
If Redis specified in requirement.yaml will be deployed even though users use an external Redis, this commit removes the dependency and use the one of Harbor own. In this way, we can controll the Redis through template.

Signed-off-by: Wenkai Yin <yinw@vmware.com>