### PR TITLE
Add "subPath" and "resourcePolicy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | -----------------------    | ---------------------------------- | ----------------------- |
 | **Harbor** |
 | `persistence.enabled`     | Persistent data | `true` |
+| `persistence.resourcePolicy`     | Setting it to "keep" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted | `keep` |
 | `externalURL`       | Ther external URL for Harbor core service | `https://core.harbor.domain` |
 | `harborAdminPassword`  | The password of system admin | `Harbor12345` |
 | `secretkey` | The key used for encryption. Must be a string of 16 chars | `not-a-secure-key` |

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -41,6 +41,7 @@ spec:
         volumeMounts:
         - name: chartmuseum-data
           mountPath: /chart_storage
+          subPath: {{ .Values.chartmuseum.volumes.data.subPath }}
       volumes:
       - name: chartmuseum-data
         persistentVolumeClaim:

--- a/templates/chartmuseum/chartmuseum-pvc.yaml
+++ b/templates/chartmuseum/chartmuseum-pvc.yaml
@@ -5,6 +5,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "harbor.fullname" . }}-chartmuseum
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: chartmuseum

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data
+          subPath: {{ .Values.database.internal.volumes.data.subPath }}
       {{- if not .Values.persistence.enabled }}
       volumes:
       - name: "database-data"

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -50,6 +50,7 @@ spec:
           subPath: config.yml
         - name: job-logs
           mountPath: /var/log/jobs
+          subPath: {{ .Values.jobservice.volumes.data.subPath }}
       volumes:
       - name: jobservice-config
         configMap:

--- a/templates/jobservice/jobservice-pvc.yaml
+++ b/templates/jobservice/jobservice-pvc.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "harbor.fullname" . }}-jobservice
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: jobservice

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/redis
+          subPath: {{ .Values.redis.internal.volumes.data.subPath }}
       {{- if not .Values.persistence.enabled }}
       volumes:
       - name: data

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -87,6 +87,7 @@ spec:
         {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         - name: registry-data
           mountPath: {{ .Values.storage.filesystem.rootdirectory }}
+          subPath: {{ .Values.registry.volumes.data.subPath }}
         {{- end }}
         - name: registry-root-certificate
           mountPath: /etc/registry/root.crt
@@ -117,6 +118,7 @@ spec:
         {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         - name: registry-data
           mountPath: {{ .Values.storage.filesystem.rootdirectory }}
+          subPath: {{ .Values.registry.volumes.data.subPath }}
         {{- end }}
         - name: registry-config
           mountPath: /etc/registry/config.yml

--- a/templates/registry/registry-pvc.yaml
+++ b/templates/registry/registry-pvc.yaml
@@ -5,6 +5,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "harbor.fullname" . }}-registry
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: registry

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,8 @@
 persistence:
   enabled: true
+  # Setting it to "keep" to avoid removing PVCs during a helm delete 
+  # operation. Leaving it empty will delete PVCs after the chart deleted
+  resourcePolicy: keep
 # Ther external URL for Harbor core service. It is used to
 # 1) populate the docker/helm commands showed on portal
 # 2) populate the token service URL returned to docker/notary client
@@ -70,6 +73,7 @@ jobservice:
     data:
       # existingClaim: ""
       # storageClass: "-"
+      subPath: "jobservice"
       accessMode: ReadWriteOnce
       size: 1Gi
 # resources:
@@ -107,6 +111,7 @@ database:
       data:
         # existingClaim: ""
         # storageClass: "-"
+        subPath: "database"
         accessMode: ReadWriteOnce
         size: 1Gi
     # resources:
@@ -143,6 +148,7 @@ registry:
     data:
       # existingClaim: ""
       # storageClass: "-"
+      subPath: "registry"
       accessMode: ReadWriteOnce
       size: 5Gi
   # resources:
@@ -163,6 +169,7 @@ chartmuseum:
     data:
       # existingClaim: ""
       # storageClass: "-"
+      subPath: "chartmuseum"
       accessMode: ReadWriteOnce
       size: 5Gi
   # resources:
@@ -181,7 +188,7 @@ storage:
   # "oss" and fill the information needed in the corresponding section
   type: filesystem
   filesystem:
-    rootdirectory: /var/lib/registry
+    rootdirectory: /storage
     #maxthreads: 100
   azure:
     accountname: accountname
@@ -268,6 +275,7 @@ redis:
       data:
         # existingClaim: ""
         # storageClass: "-"
+        subPath: "redis"
         accessMode: ReadWriteOnce
         size: 1Gi
     # resources:


### PR DESCRIPTION
1. The "subPath" specifies the directory used inside PVC
2. The "resourcePolicy" is used to avoid removing PVCs during a helm delete operation

Signed-off-by: Wenkai Yin <yinw@vmware.com>