### PR TITLE
Proxy for clair

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `clair.image.repository` | Repository for clair image | `goharbor/clair-photon` |
 | `clair.image.tag` | Tag for clair image | `dev`
 | `clair.replicas` | The replica count | `1` |
+| `clair.proxy.enabled` | Enable the use of http(s) proxy | `false` |
+| `clair.proxy.http_proxy` | URL of the http proxy |
+| `clair.proxy.https_proxy` | URL of the https proxy |
 | `clair.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined
 | `clair.nodeSelector` | Node labels for pod assignment | `{}` |
 | `clair.tolerations` | Tolerations for pod assignment | `[]` |

--- a/templates/adminserver/adminserver-cm.yaml
+++ b/templates/adminserver/adminserver-cm.yaml
@@ -15,7 +15,7 @@ data:
   EXT_ENDPOINT: "{{ .Values.externalURL }}"
   CORE_URL: "http://{{ template "harbor.core" . }}"
   JOBSERVICE_URL: "http://{{ template "harbor.fullname" . }}-jobservice"
-  REGISTRY_URL: "http://{{ template "harbor.fullname" . }}-registry:5000"
+  REGISTRY_URL: "http://{{ template "harbor.registry" . }}:5000"
   TOKEN_SERVICE_URL: "http://{{ template "harbor.core" . }}/service/token"
   WITH_NOTARY: "{{ .Values.notary.enabled }}"
   NOTARY_URL: "http://{{ template "harbor.notaryServiceName" . }}:4443"

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -23,6 +23,19 @@ spec:
         image: {{ .Values.clair.image.repository }}:{{ .Values.clair.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args: ["-insecure-tls", "-config", "/etc/clair/config.yaml"]
+        env:
+        {{- if .Values.clair.proxy.enabled }}
+        {{- if .Values.clair.proxy.http_proxy }}
+        - name: HTTP_PROXY
+          value: {{ .Values.clair.proxy.http_proxy }}
+        {{- end }}
+        {{- if .Values.clair.proxy.https_proxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.clair.proxy.https_proxy }}
+        {{- end }}
+        - name: NO_PROXY
+          value: "{{ template "harbor.registry" . }},{{ template "harbor.core" . }}"
+        {{- end }}
         resources:
 {{ toYaml .Values.clair.resources | indent 10 }}
         ports:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -37,7 +37,7 @@ spec:
           - name: ADMINSERVER_URL
             value: "http://{{ template "harbor.fullname" . }}-adminserver"
           - name: REGISTRY_CONTROLLER_URL
-            value: "http://{{ template "harbor.fullname" . }}-registry:8080"
+            value: "http://{{ template "harbor.registry" . }}:8080"
           - name: LOG_LEVEL
             value: debug
           - name: GODEBUG

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "harbor.fullname" . }}-registry"
+  name: "{{ template "harbor.registry" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ template "harbor.fullname" . }}-registry"
+  name: "{{ template "harbor.registry" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: registry
@@ -26,7 +26,7 @@ spec:
         args: ["serve", "/etc/registry/config.yml"]
         envFrom:
         - secretRef:
-            name: "{{ template "harbor.fullname" . }}-registry"
+            name: "{{ template "harbor.registry" . }}"
         ports:
         - containerPort: 5000
         - containerPort: 5001
@@ -48,7 +48,7 @@ spec:
         args: ["serve", "/etc/registry/config.yml"]
         envFrom:
         - secretRef:
-            name: "{{ template "harbor.fullname" . }}-registry"
+            name: "{{ template "harbor.registry" . }}"
         env:
           - name: CORE_SECRET
             valueFrom:
@@ -78,11 +78,11 @@ spec:
           secretName: {{ template "harbor.core" . }}
       - name: registry-config
         configMap:
-          name: "{{ template "harbor.fullname" . }}-registry"
+          name: "{{ template "harbor.registry" . }}"
       - name: registry-data
       {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         persistentVolumeClaim:
-          claimName: {{ .Values.registry.volumes.data.existingClaim | default (printf "%s-registry" (include "harbor.fullname" .)) }}  
+          claimName: {{ .Values.registry.volumes.data.existingClaim | default (include "harbor.registry" .) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/templates/registry/registry-pvc.yaml
+++ b/templates/registry/registry-pvc.yaml
@@ -4,7 +4,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "harbor.fullname" . }}-registry
+  name: {{ template "harbor.registry" . }}
   {{- if eq .Values.persistence.resourcePolicy "keep" }}
   annotations:
     helm.sh/resource-policy: keep

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "harbor.fullname" . }}-registry"
+  name: "{{ template "harbor.registry" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "harbor.fullname" . }}-registry"
+  name: "{{ template "harbor.registry" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -299,7 +299,12 @@ clair:
     repository: goharbor/clair-photon
     tag: dev
   replicas: 1
-  # The interval of clair updaters, the unit is hour, 
+  # Use an http(s) proxy to update vulnerabilities database from internet
+  proxy:
+    enabled: false
+    http_proxy:
+    https_proxy:
+  # The interval of clair updaters, the unit is hour,
   # set to 0 to disable the updaters
   updatersInterval: 12
   # resources:


### PR DESCRIPTION
Use an http(s) proxy to update vulnerabilities database from internet if clair container is behind corporate proxies.