### PR TITLE
Upgrade Kubernetes API version and remove the mutable label for upgrade

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -20,7 +20,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "harbor.labels" -}}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+chart: {{ .Chart.Name }}
 app: "{{ template "harbor.name" . }}"
 {{- end -}}
 

--- a/templates/adminserver/adminserver-dpl.yaml
+++ b/templates/adminserver/adminserver-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-adminserver"

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.chartmuseum.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-chartmuseum"

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.clair.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.fullname" . }}-clair

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.core" . }}
@@ -7,6 +7,10 @@ metadata:
     component: core
 spec:
   replicas: {{ .Values.core.replicas }}
+  selector:
+    matchLabels:
+{{ include "harbor.matchLabels" . | indent 6 }}
+      component: core
   template:
     metadata:
       labels:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.database.type "internal" -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "harbor.fullname" . }}-database"

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-jobservice"

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.notary.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.fullname" . }}-notary-server

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.notary.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.fullname" . }}-notary-signer

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.portal" . }}"
@@ -7,6 +7,10 @@ metadata:
     component: portal
 spec:
   replicas: {{ .Values.portal.replicas }}
+  selector:
+    matchLabels:
+{{ include "harbor.matchLabels" . | indent 6 }}
+      component: portal
   template:
     metadata:
       labels:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.redis.type "internal" -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "harbor.redis" . }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.fullname" . }}-registry"


### PR DESCRIPTION
1. Upgrade the Kubernetes API versions to the latest stable ones
2. Remove the mutable label for helm release upgrade, related issue: https://github.com/helm/charts/issues/7680

Signed-off-by: Wenkai Yin <yinw@vmware.com>