### PR TITLE
Use emtpyDir as volume for registry and chartmuseum

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -37,15 +37,17 @@ spec:
                 key: secret
         ports:
         - containerPort: 9999
-      {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         volumeMounts:
         - name: chartmuseum-data
           mountPath: /chart_storage
           subPath: {{ .Values.chartmuseum.volumes.data.subPath }}
       volumes:
       - name: chartmuseum-data
+      {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         persistentVolumeClaim:
           claimName: {{ .Values.chartmuseum.volumes.data.existingClaim | default (printf "%s-chartmuseum" (include "harbor.fullname" .)) }}
+      {{- else }}
+        emptyDir: {}
       {{- end }}
       {{- with .Values.chartmuseum.nodeSelector }}
       nodeSelector:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -31,11 +31,9 @@ spec:
         - containerPort: 5000
         - containerPort: 5001
         volumeMounts:
-        {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         - name: registry-data
           mountPath: {{ .Values.storage.filesystem.rootdirectory }}
           subPath: {{ .Values.registry.volumes.data.subPath }}
-        {{- end }}
         - name: registry-root-certificate
           mountPath: /etc/registry/root.crt
           subPath: tokenServiceRootCertBundle
@@ -65,11 +63,9 @@ spec:
         ports:
         - containerPort: 8080
         volumeMounts:
-        {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         - name: registry-data
           mountPath: {{ .Values.storage.filesystem.rootdirectory }}
           subPath: {{ .Values.registry.volumes.data.subPath }}
-        {{- end }}
         - name: registry-config
           mountPath: /etc/registry/config.yml
           subPath: config.yml
@@ -83,10 +79,12 @@ spec:
       - name: registry-config
         configMap:
           name: "{{ template "harbor.fullname" . }}-registry"
-      {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
       - name: registry-data
+      {{- if and .Values.persistence.enabled (eq .Values.storage.type "filesystem") }}
         persistentVolumeClaim:
           claimName: {{ .Values.registry.volumes.data.existingClaim | default (printf "%s-registry" (include "harbor.fullname" .)) }}  
+      {{- else }}
+        emptyDir: {}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
When the persistence is disabled, use the emptyDir as the volume for registry and chartmuseum to fix permission deny issue when pushing images.

Signed-off-by: Wenkai Yin <yinw@vmware.com>