### PR TITLE
[0.3.0]Add helmignore to avoid uploading useless files to tiller when deploying chart

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,4 @@
+docs/*
+.git/*
+.gitignore
+CONTRIBUTING.md


### PR DESCRIPTION
Some useless files, such as .git, docs/*, will be uploaded to tiller when deploying Harbor chart, this will cause error https://github.com/helm/helm/issues/1996. The helmignore can be used to ignore these files

Signed-off-by: Wenkai Yin <yinw@vmware.com>