### PR TITLE
Make job logger configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `jobservice.image.tag` | Tag for jobservice image | `dev` |
 | `jobservice.replicas` | The replica count | `1` |
 | `jobservice.maxJobWorkers` | The max job workers | `10` |
+| `jobservice.jobLogger` | The logger for jobs: `file`, `database` or `stdout` | `file` |
 | `jobservice.resources` | [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) to allocate for container   | undefined |
 | `jobservice.nodeSelector` | Node labels for pod assignment | `{}` |
 | `jobservice.tolerations` | Tolerations for pod assignment | `[]` |

--- a/docs/High Availability.md
+++ b/docs/High Availability.md
@@ -9,8 +9,7 @@ Deploy Harbor on K8S via helm to make it highly available, that is, if one of no
 - High available ingress controller (Harbor does not manage the external endpoint)
 - High available PostgreSQL database (Harbor does not handle the deployment of HA of database)
 - High available Redis (Harbor does not handle the deployment of HA of Redis)
-- PVC that can be shared across nodes. Users can use `StorageClass` on K8S cluster for dynamically provision or use the existing PVC.
-- External object storage for storing image and chart data(optional, PVC can be used for storing)
+- PVC that can be shared across nodes or external object storage
 
 ## Architecture
 Most of Harbor's components are stateless now.  So we can simply increase the replica of the pods to make sure the components are distributed to multiple worker nodes, and leverage the "Service" mechanism of K8S to ensure the connectivity across pods.
@@ -49,7 +48,7 @@ Configure the followings items in `values.yaml`, you can also set them as parame
 
    You can also use the existing PVCs to store data, set `persistence.persistentVolumeClaim.registry.existingClaim`, `persistence.persistentVolumeClaim.chartmuseum.existingClaim` and `persistence.persistentVolumeClaim.jobservice.existingClaim`.  
 
-   Cloud storage also can be used to store images and charts. Set the `persistence.imageChartStorage.type` to the value you want to use and fill the corresponding section. Notes: PVC is also needed to store job logs.
+   If you have no PVCs that can be shared across nodes, you can use external object storage to store images and charts and store the job logs in database. Set the `persistence.imageChartStorage.type` to the value you want to use and fill the corresponding section and set `jobservice.jobLogger` to `database`.  
 
 - **Replica**   
    Set `portal.replicas`, `adminserver.replicas`, `core.replicas`, `jobservice.replicas`, `registry.replicas`, `chartmuseum.replicas`, `clair.replicas`, `notary.server.replicas` and `notary.signer.replicas` to `n`(`n`>=2).

--- a/templates/jobservice/jobservice-cm.yaml
+++ b/templates/jobservice/jobservice-cm.yaml
@@ -15,6 +15,7 @@ data:
         redis_url: "{{ template "harbor.redisForJobservice" . }}"
         namespace: "harbor_job_service_namespace"
     job_loggers:
+      {{- if eq .Values.jobservice.jobLogger "file" }}
       - name: "FILE"
         level: {{ .Values.logLevel | upper }}
         settings: # Customized settings of logger
@@ -23,6 +24,15 @@ data:
           duration: 14 #days
           settings: # Customized settings of sweeper
             work_dir: "/var/log/jobs"
+      {{- else if eq .Values.jobservice.jobLogger "database" }}
+      - name: "DB"
+        level: {{ .Values.logLevel | upper }}
+        sweeper:
+          duration: 14 #days
+      {{- else }}
+      - name: "STD_OUTPUT"
+        level: {{ .Values.logLevel | upper }}
+      {{- end }}
     #Loggers for the job service
     loggers:
       - name: "STD_OUTPUT"

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -66,7 +66,7 @@ spec:
         configMap:
           name: "{{ template "harbor.jobservice" . }}"
       - name: job-logs
-        {{- if .Values.persistence.enabled }}
+        {{- if and .Values.persistence.enabled (eq .Values.jobservice.jobLogger "file") }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.persistentVolumeClaim.jobservice.existingClaim | default (include "harbor.jobservice" .) }}  
         {{- else }}

--- a/templates/jobservice/jobservice-pvc.yaml
+++ b/templates/jobservice/jobservice-pvc.yaml
@@ -1,5 +1,6 @@
 {{- $jobservice := .Values.persistence.persistentVolumeClaim.jobservice -}}
 {{- if and .Values.persistence.enabled (not $jobservice.existingClaim) }}
+{{- if eq .Values.jobservice.jobLogger "file" }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -24,4 +25,5 @@ spec:
   storageClassName: {{ $jobservice.storageClass }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -265,6 +265,8 @@ jobservice:
     tag: dev
   replicas: 1
   maxJobWorkers: 10
+  # The logger for jobs: "file", "database" or "stdout"
+  jobLogger: file
 # resources:
 #   requests:
 #     memory: 256Mi


### PR DESCRIPTION
This commit makes the job logger can be configured. In HA deployment, if users have no PVCs that can be shared across node, they can use external object storage to store images and charts.

Signed-off-by: Wenkai Yin <yinw@vmware.com>