### PR TITLE
Add support for customizing pod annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `nginx.nodeSelector` | Node labels for pod assignment | `{}` |
 | `nginx.tolerations` | Tolerations for pod assignment | `[]` |
 | `nginx.affinity` | Node/Pod affinities | `{}` |
+| `nginx.podAnnotations` | Annotations to add to the nginx pod | `{}` |
 | **Portal** |
 | `portal.image.repository` | Repository for portal image | `goharbor/harbor-portal` |
 | `portal.image.tag` | Tag for portal image | `dev` |
@@ -137,6 +138,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `portal.nodeSelector` | Node labels for pod assignment | `{}` |
 | `portal.tolerations` | Tolerations for pod assignment | `[]` |
 | `portal.affinity` | Node/Pod affinities | `{}` |
+| `portal.podAnnotations` | Annotations to add to the portal pod | `{}` |
 | **Core** |
 | `core.image.repository` | Repository for Harbor core image | `goharbor/harbor-core` |
 | `core.image.tag` | Tag for Harbor core image | `dev` |
@@ -145,6 +147,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `core.nodeSelector` | Node labels for pod assignment | `{}` |
 | `core.tolerations` | Tolerations for pod assignment | `[]` |
 | `core.affinity` | Node/Pod affinities | `{}` |
+| `core.podAnnotations` | Annotations to add to the core pod | `{}` |
 | **Adminserver** |
 | `adminserver.image.repository` | Repository for adminserver image | `goharbor/harbor-adminserver` |
 | `adminserver.image.tag` | Tag for adminserver image | `dev` |
@@ -153,6 +156,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `adminserver.nodeSelector` | Node labels for pod assignment | `{}` |
 | `adminserver.tolerations` | Tolerations for pod assignment | `[]` |
 | `adminserver.affinity` | Node/Pod affinities | `{}` |
+| `adminserver.podAnnotations` | Annotations to add to the adminserver pod | `{}` |
 | **Jobservice** |
 | `jobservice.image.repository` | Repository for jobservice image | `goharbor/harbor-jobservice` |
 | `jobservice.image.tag` | Tag for jobservice image | `dev` |
@@ -163,6 +167,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `jobservice.nodeSelector` | Node labels for pod assignment | `{}` |
 | `jobservice.tolerations` | Tolerations for pod assignment | `[]` |
 | `jobservice.affinity` | Node/Pod affinities | `{}` |
+| `jobservice.podAnnotations` | Annotations to add to the jobservice pod | `{}` |
 | **Registry** |
 | `registry.registry.image.repository` | Repository for registry image | `goharbor/registry-photon` |
 | `registry.registry.image.tag` | Tag for registry image | `dev` |
@@ -173,6 +178,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `registry.nodeSelector` | Node labels for pod assignment | `{}` |
 | `registry.tolerations` | Tolerations for pod assignment | `[]` |
 | `registry.affinity` | Node/Pod affinities | `{}` |
+| `registry.podAnnotations` | Annotations to add to the registry pod | `{}` |
 | **Chartmuseum** |
 | `chartmuseum.enabled` | Enable chartmusuem to store chart | `true` |
 | `chartmuseum.image.repository` | Repository for chartmuseum image | `goharbor/chartmuseum-photon` |
@@ -182,6 +188,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `chartmuseum.nodeSelector` | Node labels for pod assignment | `{}` |
 | `chartmuseum.tolerations` | Tolerations for pod assignment | `[]` |
 | `chartmuseum.affinity` | Node/Pod affinities | `{}` |
+| `chartmuseum.podAnnotations` | Annotations to add to the chart museum pod | `{}` |
 | **Clair** |
 | `clair.enabled` | Enable Clair | `true` |
 | `clair.image.repository` | Repository for clair image | `goharbor/clair-photon` |
@@ -194,6 +201,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `clair.nodeSelector` | Node labels for pod assignment | `{}` |
 | `clair.tolerations` | Tolerations for pod assignment | `[]` |
 | `clair.affinity` | Node/Pod affinities | `{}` |
+| `clair.podAnnotations` | Annotations to add to the clair pod | `{}` |
 | **Notary** |
 | `notary.enabled` | Enable Notary? | `true` |
 | `notary.server.image.repository` | Repository for notary server image | `goharbor/notary-server-photon` |
@@ -205,6 +213,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `notary.nodeSelector` | Node labels for pod assignment | `{}` |
 | `notary.tolerations` | Tolerations for pod assignment | `[]` |
 | `notary.affinity` | Node/Pod affinities | `{}` |
+| `notary.podAnnotations` | Annotations to add to the notary pod | `{}` |
 | **Database** |
 | `database.type` | If external database is used, set it to `external` | `internal` |
 | `database.internal.image.repository` | Repository for database image | `goharbor/harbor-db` |
@@ -223,6 +232,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `database.external.notaryServerDatabase` | The database used by Notary server | `notary_server` |
 | `database.external.notarySignerDatabase` | The database used by Notary signer | `notary_signer` |
 | `database.external.sslmode` | Connection method of external database (require|prefer|disable) | `disable`|
+| `database.podAnnotations` | Annotations to add to the database pod | `{}` |
 | **Redis** |
 | `redis.type` | If external redis is used, set it to `external` | `internal` |
 | `redis.internal.image.repository` | Repository for redis image | `goharbor/redis-photon` |
@@ -238,3 +248,4 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `redis.external.registryDatabaseIndex` | The database index for registry | `2` |
 | `redis.external.chartmuseumDatabaseIndex` | The database index for chartmuseum | `3` |
 | `redis.external.password` | The password of external Redis | |
+| `redis.podAnnotations` | Annotations to add to the redis pod | `{}` |

--- a/templates/adminserver/adminserver-dpl.yaml
+++ b/templates/adminserver/adminserver-dpl.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/adminserver/adminserver-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/adminserver/adminserver-secrets.yaml") . | sha256sum }}
+{{- if .Values.adminserver.podAnnotations }}
+{{ toYaml .Values.adminserver.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: adminserver

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -20,6 +20,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/chartmuseum/chartmuseum-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/chartmuseum/chartmuseum-secret.yaml") . | sha256sum }}
+{{- if .Values.chartmuseum.podAnnotations }}
+{{ toYaml .Values.chartmuseum.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: chartmuseum

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -19,6 +19,9 @@ spec:
         component: clair
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/clair/clair-cm.yaml") . | sha256sum }}
+{{- if .Values.clair.podAnnotations }}
+{{ toYaml .Values.clair.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: clair

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/core/core-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/core/core-secret.yaml") . | sha256sum }}
+{{- if .Values.core.podAnnotations }}
+{{ toYaml .Values.core.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: core

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -21,6 +21,9 @@ spec:
         component: database
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/database/database-secret.yaml") . | sha256sum }}
+{{- if .Values.database.podAnnotations }}
+{{ toYaml .Values.database.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       initContainers:
       - name: "remove-lost-found"

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/jobservice/jobservice-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jobservice/jobservice-secrets.yaml") . | sha256sum }}
+{{- if .Values.jobservice.podAnnotations }}
+{{ toYaml .Values.jobservice.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: jobservice

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       {{- if eq (include "harbor.autoGenCertForNginx" .) "true" }}
         checksum/secret: {{ include (print $.Template.BasePath "/nginx/secret.yaml") . | sha256sum }}
       {{- end }}
+{{- if .Values.nginx.podAnnotations }}
+{{ toYaml .Values.nginx.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: nginx

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -19,6 +19,9 @@ spec:
         component: notary-server
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/notary/notary-cm.yaml") . | sha256sum }}
+{{- if .Values.notary.podAnnotations }}
+{{ toYaml .Values.notary.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: notary-server

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
 {{ include "harbor.matchLabels" . | indent 8 }}
         component: portal
+      annotations:
+{{- if .Values.portal.podAnnotations }}
+{{ toYaml .Values.portal.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: portal

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
         component: redis
+{{- if .Values.redis.podAnnotations }}
+      annotations:
+{{ toYaml .Values.redis.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: redis

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/registry/registry-secret.yaml") . | sha256sum }}
+{{- if .Values.registry.podAnnotations }}
+{{ toYaml .Values.registry.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: registry

--- a/values.yaml
+++ b/values.yaml
@@ -219,6 +219,8 @@ nginx:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 portal:
   image:
@@ -386,6 +388,8 @@ database:
     notaryServerDatabase: "notary_server"
     notarySignerDatabase: "notary_signer"
     sslmode: "disable"
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 redis:
   # if external Redis is used, set "type" to "external"
@@ -412,3 +416,5 @@ redis:
     registryDatabaseIndex: "2"
     chartmuseumDatabaseIndex: "3"
     password: ""
+  ## Additional deployment annotations
+  podAnnotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -232,6 +232,8 @@ portal:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 core:
   image:
@@ -245,6 +247,8 @@ core:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 adminserver:
   image:
@@ -258,6 +262,8 @@ adminserver:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 jobservice:
   image:
@@ -274,6 +280,8 @@ jobservice:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 registry:
   registry:
@@ -292,6 +300,8 @@ registry:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 chartmuseum:
   enabled: true
@@ -306,6 +316,8 @@ chartmuseum:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 clair:
   enabled: true
@@ -326,6 +338,8 @@ clair:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 notary:
   enabled: true
@@ -342,6 +356,8 @@ notary:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Additional deployment annotations
+  podAnnotations: {}
 
 database:
   # if external database is used, set "type" to "external"


### PR DESCRIPTION
## what

Allow annotations to be added to pods

## why

We use [kiam](https://github.com/uswitch/kiam) to managing access to AWS, and it requires annotating pods with the role they should assume. In order to use S3 as a backend, we need this annotation added.

This should help with other use cases as well