### PR TITLE
Quote the chunksize to avoid the helm bug

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -152,7 +152,7 @@ persistence:
       # TODO: support the keyfile of gcs
       #keyfile: /path/to/keyfile
       #rootdirectory: /gcs/object/name/prefix
-      #chunksize: 5242880
+      #chunksize: "5242880"
     s3:
       region: us-west-1
       bucket: bucketname
@@ -163,7 +163,7 @@ persistence:
       #keyid: mykeyid
       #secure: true
       #v4auth: true
-      #chunksize: 5242880
+      #chunksize: "5242880"
       #rootdirectory: /s3/object/name/prefix
       #storageclass: STANDARD
     swift:


### PR DESCRIPTION
Due to the bug of helm https://github.com/helm/helm/issues/1707, the chunksize will be rendered in scientific notation. Quote it to avoid this.

Signed-off-by: Wenkai Yin <yinw@vmware.com>