### PR TITLE
Generate the certificate according to the common name type

### DIFF
--- a/templates/nginx/secret.yaml
+++ b/templates/nginx/secret.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "harbor.autoGenCertForNginx" .) "true" }}
 {{- $ca := genCA "harbor-ca" 365 }}
-{{- $cert := genSignedCert .Values.expose.tls.commonName (list .Values.expose.tls.commonName) nil 365 $ca }}
+{{- $cn := .Values.expose.tls.commonName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +9,15 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if regexMatch `^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$` $cn }}
+  {{- $cert := genSignedCert $cn (list $cn) nil 365 $ca }}
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- else }}
+  {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Putting the common name to ip list or alternate DNS name list when creating the certificate

Signed-off-by: Wenkai Yin <yinw@vmware.com>