### PR TITLE
[0.3.0]Fix bug in the configmap of chartmuseum

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -8,8 +8,8 @@ metadata:
 data:
   PORT: "9999"
   CACHE: "redis"
-  CACHE_REDIS_ADDR: "{{ template "harbor.redis.host" }}:{{ template "harbor.redis.port" }}"
-  CACHE_REDIS_DB: "{{ template "harbor.redis.databaseIndex" }}"
+  CACHE_REDIS_ADDR: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
+  CACHE_REDIS_DB: "{{ template "harbor.redis.databaseIndex" . }}"
   BASIC_AUTH_USER: "chart_controller"
   DEPTH: "1"
   STORAGE: "local"


### PR DESCRIPTION
Pass the context "." as a param in calling "tempalte" function

Signed-off-by: Wenkai Yin <yinw@vmware.com>