### PR TITLE
Fix s3 backend push retrying issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 |`persistence.persistentVolumeClaim.redis.subPath`     | The sub path used in the volume. If external Redis is used, the setting will be ignored | |
 |`persistence.persistentVolumeClaim.redis.accessMode`     | The access mode of the volume. If external Redis is used, the setting will be ignored | `ReadWriteOnce` |
 |`persistence.persistentVolumeClaim.redis.size`     | The size of the volume. If external Redis is used, the setting will be ignored | `1Gi` |
+|`persistence.imageChartStorage.disableredirect`     | The configuration for managing redirects from content backends. For backends which not supported it (such as using minio for `s3` storage type), please set it to `true` to disable redirects. Refer to the [guide](https://github.com/docker/distribution/blob/master/docs/configuration.md#redirect) for more information about the detail | `false` |
 |`persistence.imageChartStorage.type`     | The type of storage for images and charts: `filesystem`, `azure`, `gcs`, `s3`, `swift` or `oss`. The type must be `filesystem` if you want to use persistent volumes for registry and chartmuseum. Refer to the [guide](https://github.com/docker/distribution/blob/master/docs/configuration.md#storage) for more information about the detail | `filesystem` |
 | |
 | `externalURL` | The external URL for Harbor core service | `https://core.harbor.domain` |

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -136,6 +136,8 @@ data:
           enabled: false
       delete:
         enabled: true
+      redirect:
+        disable: {{ $storage.disableredirect }}
     redis:
       addr: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
       password: {{ template "harbor.redis.rawPassword" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -134,6 +134,13 @@ persistence:
   # https://github.com/docker/distribution/blob/master/docs/configuration.md#storage 
   # for the detail.
   imageChartStorage:
+    # Specify whether to disable `redirect` for images and chart storage, for 
+    # backends which not supported it (such as using minio for `s3` storage type), please disable 
+    # it. To disable redirects, simply set `disableredirect` to `true` instead. 
+    # Refer to 
+    # https://github.com/docker/distribution/blob/master/docs/configuration.md#redirect  
+    # for the detail.
+    disableredirect: false
     # Specify the type of storage: "filesystem", "azure", "gcs", "s3", "swift", 
     # "oss" and fill the information needed in the corresponding section. The type
     # must be "filesystem" if you want to use persistent volumes for registry


### PR DESCRIPTION
When using `s3` for the backend type, `docker push` cannot successfully push the image, and will always be `retrying`.
If switch the backend to `filesystem`, this issue was gone.

Adding the following to the registry config.yml manually fixes my issue.

```yaml
storage:
  redirect:
    disable: true
```

And thanks for @rizwan-kh  helping!!

issue links:
https://github.com/goharbor/harbor/issues/5240
https://github.com/vmware/harbor-boshrelease/issues/15