### PR TITLE
Allow user to specify custom URI for harbor

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -35,27 +35,51 @@ spec:
   - host: {{ $ingress.hosts.core }}
     http:
       paths:
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}
+      {{- else }}
       - path: /
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.portal" . }}
           servicePort: 80
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}api/
+      {{- else }}
       - path: /api/
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: 80
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}service/
+      {{- else }}
       - path: /service/
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: 80
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}v2/
+      {{- else }}
       - path: /v2/
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: 80
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}chartrepo/
+      {{- else }}
       - path: /chartrepo/
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: 80
+      {{- if $ingress.paths.core }}
+      - path: {{ $ingress.paths.core }}c/
+      {{- else }}
       - path: /c/
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: 80
@@ -63,7 +87,11 @@ spec:
   - host: {{ $ingress.hosts.notary }}
     http:
       paths:
+      {{- if $ingress.paths.notary }}
+      - path: {{ $ingress.paths.notary }}
+      {{- else }}
       - path: /
+      {{- end }}
         backend:
           serviceName: {{ template "harbor.notary-server" . }}
           servicePort: 4443

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,12 @@ expose:
     hosts:
       core: core.harbor.domain
       notary: notary.harbor.domain
+    paths:
+      # By default, harbor is meant to be deployed using its own hostname
+      # but if you need to re-use an hostname, you could use custom paths.
+      # (don't forget to specify trailing slashes).
+      # core: /harbor/
+      # notary: /notary/
     annotations:
       ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
I provide custom configuration keys meant to configure ingress to use custom URI.

It can be usefull if you want to use the same hostname for harbor and notary, for example. Or to re-use an  hostname where you have already deployed an application.

This merge request cannot be used on its own because api URLs are hardcoded in Angular application.

I'll open an issue on harbor project to ask for help on this part.