### PR TITLE
Configure CHART_URL for chart museum

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -22,7 +22,7 @@ data:
   DISABLE_API: "false"
   DISABLE_STATEFILES: "false"
   ALLOW_OVERWRITE: "true"
-  CHART_URL:
+  CHART_URL: {{ .Values.externalURL }}/chartrepo
   AUTH_ANONYMOUS_GET: "false"
   TLS_CERT:
   TLS_KEY:


### PR DESCRIPTION
## Issue

Issue #149 

Chart Museum is not configured with a `CHART_URL` which results in it returning relative URLs in the index:
```
harbor:
  - appVersion: 1.7.0
    home: https://goharbor.io
    ....
    urls:
    - charts/harbor-1.7.0.tgz
    version: 1.7.0
```

This causes issues for some tools that expect a URL.

## Fix

I went with always setting the `CHART_URL` based on the `externalURL` value. The alternative would be to introduce a new key for the CHART_URL that defaults to empty and preserves the existing relative URL behavior.

The downside of using `externalURL` is that it may cause upgrade issues due to a bug in chart museum: https://github.com/helm/chartmuseum/issues/157 . Chart Museum does not rewrite the cache when the `CHART_URL` changes, which means upgrading the chart will cause the index to return relative for existing charts, and absolute for newly uploaded charts/versions