### PR TITLE
Revert "Configure CHART_URL for chart museum"

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -22,7 +22,7 @@ data:
   DISABLE_API: "false"
   DISABLE_STATEFILES: "false"
   ALLOW_OVERWRITE: "true"
-  CHART_URL: {{ .Values.externalURL }}/chartrepo
+  CHART_URL:
   AUTH_ANONYMOUS_GET: "false"
   TLS_CERT:
   TLS_KEY:


### PR DESCRIPTION
Reverts goharbor/harbor-helm#150
The PR #150 causes new issue: https://github.com/goharbor/harbor/issues/6903. 
Harbor doesn't support conifgure chart_url fow now, there is an issue https://github.com/goharbor/harbor/issues/6572 to track this. After the issue is fixed, we can add the support in chart