### PR TITLE
Reverts #150

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -22,7 +22,7 @@ data:
   DISABLE_API: "false"
   DISABLE_STATEFILES: "false"
   ALLOW_OVERWRITE: "true"
-  CHART_URL: {{ .Values.externalURL }}/chartrepo
+  #CHART_URL: {{ .Values.externalURL }}/chartrepo
   AUTH_ANONYMOUS_GET: "false"
   TLS_CERT:
   TLS_KEY:


### PR DESCRIPTION
Reverts #150
The PR #150 causes new issue: [goharbor/harbor#6903](https://github.com/goharbor/harbor/issues/6903).
Harbor doesn't support conifgure chart_url fow now, there is an issue [goharbor/harbor#6572](https://github.com/goharbor/harbor/issues/6572) to track this. After the issue is fixed, we can add the support in chart

Signed-off-by: Wenkai Yin <yinw@vmware.com>