### PR TITLE
Disable validation for registry

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -155,6 +155,8 @@ data:
         realm: "{{ .Values.externalURL }}/service/token"
         rootcertbundle: /etc/registry/root.crt
         service: harbor-registry
+    validation:
+      disabled: true
     notifications:
       endpoints:
         - name: harbor


### PR DESCRIPTION
Disable validation for registry to fix Docker registry not working with Windows layers.

See docker/distribution#2795 for more details.

Signed-off-by: He Weiwei <hweiwei@vmware.com>