### PR TITLE
Bug fix: empty the secret name used by Harbor

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -264,11 +264,18 @@ host:port,pool_size,password
 
 {{- define "harbor.certificate-secret" -}}
   {{- $tls := .Values.expose.tls -}}
-  {{- $secret := "" -}}
-    {{- if $tls.secretName }}
-      {{- $secret = $tls.secretName }}
-    {{- else }}
-      {{- $secret = (include "harbor.certificate" .) }}
-    {{- end }}
-  {{- printf "%s" $secret -}}
+  {{- if $tls.secretName }}
+    {{- printf "%s" $tls.secretName -}}
+  {{- else }}
+    {{- printf "%s" (include "harbor.certificate" .) -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.common-name" -}}
+  {{- $expose := .Values.expose }}
+  {{- if and (eq $expose.type "ingress") $expose.ingress.host }}
+    {{- printf "%s" $expose.ingress.host -}}
+  {{- else }}
+    {{- printf "%s" $expose.tls.commonName -}}
+  {{- end }}
 {{- end -}}

--- a/templates/common/certificate-secret.yaml
+++ b/templates/common/certificate-secret.yaml
@@ -1,12 +1,5 @@
 {{- if eq (include "harbor.autoGenCert" .) "true" }}
-{{- $expose := .Values.expose }}
-{{- $cn := "" }}
-{{- if and (eq $expose.type "ingress") $expose.ingress.host }}
-{{- $cn = $expose.ingress.host }}
-{{- else }}
-{{- $cn = $expose.tls.commonName }}
-{{- end }}
-{{- $cn = (required "The \"expose.tls.commonName\" is required!" $cn) }}
+{{- $cn := (required "The \"expose.tls.commonName\" is required!" (include "harbor.common-name" .)) }}
 {{- $ca := genCA "harbor-ca" 365 }}
 apiVersion: v1
 kind: Secret

--- a/values.yaml
+++ b/values.yaml
@@ -15,7 +15,7 @@ expose:
     # "tls.key" - the private key
     # "ca.crt" - the certificate of CA
     # These files will be generated automatically if the "secretName" is not set
-    secretName: "cert"
+    secretName: ""
     # The commmon name used to generate the certificate, it's necessary
     # when the type isn't "ingress" and "secretName" is null
     commonName: ""


### PR DESCRIPTION
This commit makes the secret name used by Harbor empty by default

Signed-off-by: Wenkai Yin <yinw@vmware.com>