### PR TITLE
Allow ability to disable self-registration

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -45,3 +45,4 @@ data:
   PORTAL_URL: "http://{{ template "harbor.portal" . }}"
   REGISTRYCTL_URL: "http://{{ template "harbor.registry" . }}:8080"
   CLAIR_HEALTH_CHECK_SERVER_URL: "http://{{ template "harbor.clair" . }}:6061"
+  SELF_REGISTRATION: "{{ .Values.core.selfRegistration }}"

--- a/values.yaml
+++ b/values.yaml
@@ -268,6 +268,9 @@ core:
   # They will be automatically generated if not set
   secretName: ""
 
+  ## String of "on" or "off"
+  selfRegistration: "on"
+
 jobservice:
   image:
     repository: goharbor/harbor-jobservice


### PR DESCRIPTION
## What

In our use case, we'd like not to allow people to register into our
portal, and would prefer to disable that option declaratively via
`values.yaml` file.

I'm not certain that this will be picked up by harbor application but
previously similar thing has been part of the AdminServer. Now that it's
gone there is no trace of using this variable.

Re-adding it and allowing a customisation would be great.

## How to review

- Code review may be sufficient
- I'd like a confirmation weather or not that would be picked up by the app itself
