### PR TITLE
Support optional annotations on services

### DIFF
--- a/templates/nginx/service.yaml
+++ b/templates/nginx/service.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ $clusterIP.name }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
+{{- with $clusterIP.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: ClusterIP
   ports:
@@ -28,6 +32,10 @@ spec:
   name: {{ $nodePort.name }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
+{{- with $nodePort.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: NodePort
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,7 @@ expose:
   clusterIP:
     # The name of ClusterIP service
     name: harbor
+    annotations: {}
     ports:
       # The service port Harbor listens on when serving with HTTP
       httpPort: 80
@@ -59,6 +60,7 @@ expose:
   nodePort:
     # The name of NodePort service
     name: harbor
+    annotations: {}
     ports:
       http:
         # The service port Harbor listens on when serving with HTTP


### PR DESCRIPTION
Annotations are useful on services if you're using Ambassador or external-dns for example.