### PR TITLE
Generated notary certificates in secret instead of configmap

### DIFF
--- a/templates/notary/notary-cm.yaml
+++ b/templates/notary/notary-cm.yaml
@@ -7,16 +7,6 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
     component: notary
 data:
-  {{ $ca := genCA "harbor-notary-ca" 365 }}
-  {{ $cert := genSignedCert (include "harbor.notary-signer" .) nil nil 365 $ca }}
-  {{- if not .Values.notary.secretName }}
-  notary-signer-ca.crt: |
-{{ $ca.Cert | indent 4 }}
-  notary-signer.crt: |
-{{ $cert.Cert | indent 4 }}
-  notary-signer.key: |
-{{ $cert.Key | indent 4 }}
-  {{- end }}
   server-config.postgres.json: |
     {
       "server": {

--- a/templates/notary/notary-cm.yaml
+++ b/templates/notary/notary-cm.yaml
@@ -16,7 +16,7 @@ data:
         "type": "remote",
         "hostname": "{{ template "harbor.notary-signer" . }}",
         "port": "7899",
-        "tls_ca_file": "/etc/ssl/ca.crt",
+        "tls_ca_file": "/etc/ssl/tls.ca",
         "key_algorithm": "ecdsa"
       },
       "logging": {

--- a/templates/notary/notary-cm.yaml
+++ b/templates/notary/notary-cm.yaml
@@ -16,11 +16,7 @@ data:
         "type": "remote",
         "hostname": "{{ template "harbor.notary-signer" . }}",
         "port": "7899",
-{{- if not .Values.notary.secretName }}
-        "tls_ca_file": "./notary-signer-ca.crt",
-{{- else }}
-        "tls_ca_file": "/etc/ssl/notary/cert/notary-signer-ca.crt",
-{{- end }}
+        "tls_ca_file": "/etc/ssl/ca.crt",
         "key_algorithm": "ecdsa"
       },
       "logging": {
@@ -44,13 +40,8 @@ data:
     {
       "server": {
         "grpc_addr": ":7899",
-{{- if not .Values.notary.secretName }}
-        "tls_cert_file": "./notary-signer.crt",
-        "tls_key_file": "./notary-signer.key"
-{{- else }}
-        "tls_cert_file": "/etc/ssl/notary/cert/notary-signer.crt",
-        "tls_key_file": "/etc/ssl/notary/cert/notary-signer.key"
-{{- end }}
+        "tls_cert_file": "/etc/ssl/tls.crt",
+        "tls_key_file": "/etc/ssl/tls.key"
       },
       "logging": {
         "level": "{{ .Values.logLevel }}"

--- a/templates/notary/notary-cm.yaml
+++ b/templates/notary/notary-cm.yaml
@@ -16,7 +16,7 @@ data:
         "type": "remote",
         "hostname": "{{ template "harbor.notary-signer" . }}",
         "port": "7899",
-        "tls_ca_file": "/etc/ssl/tls.ca",
+        "tls_ca_file": "/etc/ssl/notary/tls.ca",
         "key_algorithm": "ecdsa"
       },
       "logging": {
@@ -40,8 +40,8 @@ data:
     {
       "server": {
         "grpc_addr": ":7899",
-        "tls_cert_file": "/etc/ssl/tls.crt",
-        "tls_key_file": "/etc/ssl/tls.key"
+        "tls_cert_file": "/etc/ssl/notary/tls.crt",
+        "tls_key_file": "/etc/ssl/notary/tls.key"
       },
       "logging": {
         "level": "{{ .Values.logLevel }}"

--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.notary.enabled (not .Values.notary.secretName) }}
+{{- if and .Values.notary.enabled (not .Values.notary.secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,9 +8,9 @@ metadata:
     component: notary
 type: Opaque
 data:
-  {{ $ca := genCA "harbor-notary-ca" 365 }}
-  {{ $cert := genSignedCert (include "harbor.notary-signer" .) nil nil 365 $ca }}
-  tls.ca: {{ $ca | b64enc | quote }}
+  {{- $ca := genCA "harbor-notary-ca" 365 }}
+  {{- $cert := genSignedCert (include "harbor.notary-signer" .) nil nil 365 $ca }}
+  tls.ca: {{ $ca.Cert | b64enc | quote }}
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}
 {{- end }}

--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.notary.enabled (not .Values.notary.secretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "harbor.notary-server" . }}
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: notary
+type: Opaque
+data:
+  {{ $ca := genCA "harbor-notary-ca" 365 }}
+  {{ $cert := genSignedCert (include "harbor.notary-signer" .) nil nil 365 $ca }}
+  tls.ca: {{ $ca | b64enc | quote }}
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+{{- end }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -44,8 +44,8 @@ spec:
           mountPath: /root.crt
           subPath: tls.crt
         - name: notary-ca
-          mountPath: /etc/ssl/ca.crt
-          subPath: ca
+          mountPath: /etc/ssl/tls.ca
+          subPath: tls.ca
       volumes:
       - name: notary-config
         configMap:

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -44,7 +44,7 @@ spec:
           mountPath: /root.crt
           subPath: tls.crt
         - name: notary-ca
-          mountPath: /etc/ssl/tls.ca
+          mountPath: /etc/ssl/notary/tls.ca
           subPath: tls.ca
       volumes:
       - name: notary-config

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -43,11 +43,9 @@ spec:
         - name: root-certificate
           mountPath: /root.crt
           subPath: tls.crt
-        {{- if .Values.notary.secretName }}
         - name: notary-ca
-          mountPath: /etc/ssl/notary/cert/notary-signer-ca.crt
+          mountPath: /etc/ssl/ca.crt
           subPath: ca
-        {{- end }}
       volumes:
       - name: notary-config
         configMap:
@@ -59,11 +57,13 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.core" . }}
           {{- end }}
-      {{- if .Values.notary.secretName }}
       - name: notary-ca
         secret:
+          {{- if .Values.notary.secretName }}
           secretName: {{ .Values.notary.secretName }}
-      {{- end }}
+          {{- else }}
+          secretName: {{ template "harbor.notary-server" . }}
+          {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -38,26 +38,19 @@ spec:
         volumeMounts:
         - name: notary-config
           mountPath: /etc/notary
-        {{- if .Values.notary.secretName }}
         - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer-ca.crt
-          subPath: ca
-        - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer.crt
-          subPath: crt
-        - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer.key
-          subPath: key
-        {{- end }}
+          mountPath: /etc/ssl
       volumes:
       - name: notary-config
         configMap:
           name: "{{ template "harbor.notary-server" . }}"
-      {{- if .Values.notary.secretName }}
       - name: notary-cert
         secret:
+          {{- if .Values.notary.secretName }}
           secretName: {{ .Values.notary.secretName }}
-      {{- end }}
+          {{- else }}
+          secretName: {{ template "harbor.notary-server" . }}
+          {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -39,7 +39,7 @@ spec:
         - name: notary-config
           mountPath: /etc/notary
         - name: notary-cert
-          mountPath: /etc/ssl
+          mountPath: /etc/ssl/notary
       volumes:
       - name: notary-config
         configMap:


### PR DESCRIPTION
Fixes #243 
- Store automatically generated notary certificates in a k8s secret for better security
- Unify notary certificate mount templating, for reduced complexity in notary-cm.yaml, notary-server.yaml and notary-signer.yaml