### PR TITLE
Setup missing ADMIRAL_URL config on core

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -26,6 +26,7 @@ data:
   WITH_NOTARY: "{{ .Values.notary.enabled }}"
   NOTARY_URL: "http://{{ template "harbor.notary-server" . }}:4443"
   CFG_EXPIRATION: "5"
+  ADMIRAL_URL: "NA"
   WITH_CLAIR: "{{ .Values.clair.enabled }}"
   CLAIR_DB_HOST: "{{ template "harbor.database.host" . }}"
   CLAIR_DB_PORT: "{{ template "harbor.database.port" . }}"


### PR DESCRIPTION
Relates to #226

When installing harbor-helm `v1.1.0` the following error appears on the core container:

```
$ kubectl logs harbor-devl-harbor-core-5ddf5ff597-mqg8w -c core -f                                                                                                                     
2019-05-31T12:00:16Z [INFO] [/replication/adapter/harbor/adapter.go:41]: the factory for adapter harbor registered                                                                                                 
2019-05-31T12:00:16Z [INFO] [/replication/adapter/dockerhub/adapter.go:24]: Factory for adapter docker-hub registered                                                                                              
2019-05-31T12:00:16Z [INFO] [/replication/adapter/native/adapter.go:30]: the factory for adapter docker-registry registered                                                                                        
2019-05-31T12:00:16Z [INFO] [/replication/adapter/huawei/huawei_adapter.go:25]: the factory of Huawei adapter was registered                                                                                       
2019-05-31T12:00:16Z [DEBUG] [/core/auth/authenticator.go:126]: Registered authentication helper for auth mode: http_auth                                                                                          
2019-05-31T12:00:16Z [DEBUG] [/core/auth/authenticator.go:126]: Registered authentication helper for auth mode: db_auth                                                                                            
2019-05-31T12:00:16Z [DEBUG] [/core/auth/authenticator.go:126]: Registered authentication helper for auth mode: ldap_auth                                                                                          
2019-05-31T12:00:16Z [DEBUG] [/core/auth/authenticator.go:126]: Registered authentication helper for auth mode: uaa_auth                                                                                           
2019-05-31T12:00:16Z [INFO] [/core/controllers/base.go:288]: Config path: /etc/core/app.conf                                                                                                                       
2019-05-31T12:00:16Z [INFO] [/core/main.go:92]: initializing configurations...                                                                                                                                     
2019-05-31T12:00:16Z [INFO] [/core/config/config.go:98]: key path: /etc/core/key                                                                                                                                   
2019-05-31T12:00:16Z [INFO] [/core/config/config.go:71]: init secret store                                                                                                                                         
2019-05-31T12:00:16Z [INFO] [/core/config/config.go:74]: init project manager based on deploy mode                                                                                                                 
2019-05-31T12:00:16Z [ERROR] [/common/config/manager.go:192]: failed to get key admiral_url, error: the configure value is not set                                                                                 
2019-05-31T12:00:16Z [ERROR] [/common/config/manager.go:192]: failed to get key admiral_url, error: the configure value is not set
```

It appears that this setting was available on the version `v1.0.0` on the `adminserver-cm.yaml` file but it  was removed on `v1.1.0`

Adding the following setting on `core-cm.yaml` fixed the issue.

Feel free to request any changes.

Thanks :)