### PR TITLE
Set default values for TLS_CERT and TLS_KEY in the Chartmuseum ConfigMap

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -24,8 +24,8 @@ data:
   ALLOW_OVERWRITE: "true"
   #CHART_URL: {{ .Values.externalURL }}/chartrepo
   AUTH_ANONYMOUS_GET: "false"
-  TLS_CERT:
-  TLS_KEY:
+  TLS_CERT: ""
+  TLS_KEY: ""
   CONTEXT_PATH:
   INDEX_LIMIT: "0"
   MAX_STORAGE_OBJECTS: "0"


### PR DESCRIPTION
This sets proper default values for TLS_CERT and TLS_KEY in the
Chartmuseum ConfigMap.

Closes #192

Signed-off-by: Dan Norris <dan.norris@netapp.com>