### PR TITLE
Add replicas option to NGINX deployment

### DIFF
--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
     component: nginx
 spec:
-  replicas: 1
+  replicas: {{ .Values.nginx.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}


### PR DESCRIPTION
Currently the `nginx.replicas` option specified in the `values.yaml` file isn't used in the deployment for NGINX.

With this change the replica count from the `values.yaml` is used in the NGINX deployment.