### PR TITLE
add registry.relativeurls value

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -143,6 +143,7 @@ data:
       addr: "{{ template "harbor.redis.host" . }}:{{ template "harbor.redis.port" . }}"
       db: {{ template "harbor.redis.registryDatabaseIndex" . }}
     http:
+      relativeurls: {{ .Values.registry.relativeurls }}
       addr: :5000
       # set via environment variable
       # secret: placeholder

--- a/values.yaml
+++ b/values.yaml
@@ -374,6 +374,8 @@ registry:
   # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
   secret: ""
+  # If true, the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL.
+  relativeurls: false
   middleware:
     enabled: false
     type: cloudFront


### PR DESCRIPTION
Add a value to config relativeurls support on registry. This is needed when expose.type is not set to ingress to avoid "unkown blob" error on image push.

Resolves #174 