### PR TITLE
Add sideCar container support

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -76,6 +76,12 @@ spec:
           mountPath: /harbor_cust_cert/custom-ca-bundle.crt
           subPath: ca.crt
         {{- end }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.chartmuseum.extraContainers }}
+{{ toYaml .Values.chartmuseum.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: chartmuseum-data
       {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "filesystem") }}
@@ -96,6 +102,12 @@ spec:
       - name: storage-service-ca
         secret:
           secretName: {{ .Values.persistence.imageChartStorage.caBundleSecretName }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.chartmuseum.extraVolumes }}
+{{ toYaml .Values.chartmuseum.extraVolumes | indent 6 }}
       {{- end }}
       {{- with .Values.chartmuseum.nodeSelector }}
       nodeSelector:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -63,10 +63,22 @@ spec:
         - name: config
           mountPath: /etc/clair/config.yaml
           subPath: config.yaml
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.clair.extraContainers }}
+{{ toYaml .Values.clair.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         secret:
           secretName: "{{ template "harbor.clair" . }}"
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.clair.extraVolumes }}
+{{ toYaml .Values.clair.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.clair.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -89,6 +89,12 @@ spec:
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
 {{- end }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.core.extraContainers }}
+{{ toYaml .Values.core.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         configMap:
@@ -130,6 +136,12 @@ spec:
       {{- end }}
       - name: psc
         emptyDir: {}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.core.extraVolumes }}
+{{ toYaml .Values.core.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -72,6 +72,12 @@ spec:
         - name: database-data
           mountPath: /var/lib/postgresql/data
           subPath: {{ $database.subPath }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.database.extraContainers }}
+{{ toYaml .Values.database.extraContainers | indent 6 }}
+      {{- end }}
       {{- if not .Values.persistence.enabled }}
       volumes:
       - name: "database-data"
@@ -82,6 +88,12 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $database.existingClaim }}
       {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.database.extraVolumes }}
+{{ toYaml .Values.database.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.database.internal.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -84,6 +84,12 @@ spec:
         - name: job-logs
           mountPath: /var/log/jobs
           subPath: {{ .Values.persistence.persistentVolumeClaim.jobservice.subPath }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.jobservice.extraContainers }}
+{{ toYaml .Values.jobservice.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: jobservice-config
         configMap:
@@ -95,6 +101,12 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.jobservice.extraVolumes }}
+{{ toYaml .Values.jobservice.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -76,6 +76,12 @@ spec:
         - name: certificate
           mountPath: /etc/nginx/cert
         {{- end }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.nginx.extraContainers }}
+{{ toYaml .Values.nginx.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         configMap:
@@ -88,6 +94,12 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.nginx" . }}
           {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.nginx.extraVolumes }}
+{{ toYaml .Values.nginx.extraVolumes | indent 6 }}
       {{- end }}
     {{- with .Values.nginx.nodeSelector }}
       nodeSelector:

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -53,6 +53,12 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/ca.crt
           subPath: ca.crt
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.notary.server.extraContainers }}
+{{ toYaml .Values.notary.server.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -71,6 +77,12 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.notary.server.extraVolumes }}
+{{ toYaml .Values.notary.server.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -51,6 +51,12 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/tls.key
           subPath: tls.key
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.notary.signer.extraContainers }}
+{{ toYaml .Values.notary.signer.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -62,6 +68,12 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.notary.signer.extraVolumes }}
+{{ toYaml .Values.notary.signer.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -47,6 +47,21 @@ spec:
           periodSeconds: 10
         ports:
         - containerPort: 8080
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.portal.extraContainers }}
+{{ toYaml .Values.portal.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if or .Values.extraVolumes .Values.portal.extraVolumes }}
+      volumes:
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.portal.extraVolumes }}
+{{ toYaml .Values.portal.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.portal.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -52,16 +52,29 @@ spec:
         - name: data
           mountPath: /var/lib/redis
           subPath: {{ $redis.subPath }}
-      {{- if not .Values.persistence.enabled }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.redis.internal.extraContainers }}
+{{ toYaml .Values.redis.internal.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if or (or (not .Values.persistence.enabled) $redis.existingClaim) (or .Values.extraVolumes .Values.redis.internal.extraVolumes) }}
       volumes:
+      {{- end }}
+      {{- if not .Values.persistence.enabled }}
       - name: data
         emptyDir: {}
       {{- else if $redis.existingClaim }}
-      volumes:
       - name: data
         persistentVolumeClaim:
           claimName: {{ $redis.existingClaim }}
       {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.redis.internal.extraVolumes }}
+{{ toYaml .Values.redis.internal.extraVolumes | indent 6 }}
+      {{- end }}
     {{- with .Values.redis.internal.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -139,6 +139,12 @@ spec:
           mountPath: /etc/registry/gcs-key.json
           subPath: gcs-key.json
         {{- end }}
+      {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- if .Values.registry.extraContainers }}
+{{ toYaml .Values.registry.extraContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: registry-root-certificate
         secret:
@@ -179,6 +185,12 @@ spec:
             - key: CLOUDFRONT_KEY_DATA
               path: pk.pem
       {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.registry.extraVolumes }}
+{{ toYaml .Values.registry.extraVolumes | indent 6 }}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -279,6 +279,11 @@ nginx:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+
 
 portal:
   image:
@@ -294,6 +299,10 @@ portal:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
 
 core:
   image:
@@ -309,6 +318,11 @@ core:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+  #
   # Secret is used when core server communicates with other components.
   # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
@@ -338,6 +352,11 @@ jobservice:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+  #
   # Secret is used when job service communicates with other components.
   # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
@@ -368,6 +387,11 @@ registry:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+  #
   # Secret is used to secure the upload state from client
   # and registry storage backend.
   # See: https://github.com/docker/distribution/blob/master/docs/configuration.md#http
@@ -405,6 +429,10 @@ chartmuseum:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
 
 clair:
   enabled: true
@@ -424,6 +452,11 @@ clair:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+
 
 notary:
   enabled: true
@@ -436,6 +469,10 @@ notary:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+    # List of extra Containers to add to the pod if needed
+    # extraContainers:
+    # List of extra volumes to add to the pod if needed
+    # extraVolumes:
   signer:
     image:
       repository: goharbor/notary-signer-photon
@@ -445,6 +482,10 @@ notary:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+    # List of extra Containers to add to the pod if needed
+    # extraContainers:
+    # List of extra volumes to add to the pod if needed
+    # extraVolumes:
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -501,6 +542,10 @@ database:
   maxOpenConns: 100
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
 
 redis:
   # if external Redis is used, set "type" to "external"
@@ -529,3 +574,12 @@ redis:
     password: ""
   ## Additional deployment annotations
   podAnnotations: {}
+  # List of extra Containers to add to the pod if needed
+  # extraContainers:
+  # List of extra volumes to add to the pod if needed
+  # extraVolumes:
+
+# List of extra Containers to add to all pods if needed
+# extraContainers:
+# List of extra volumes to add to all pods if needed
+# extraVolumes:


### PR DESCRIPTION
This sideCar container support is done through the use of a set of two
variables, applied individually for each pod in addition to a global
processing.

These two variables are the relatively de-facto standard `extraContainers` and
`extraVolumes` (for the extraContainers)

Fixes #247