### PR TITLE
Fix GC 500 error when using with imageChartStorage 'gcs'

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -134,6 +134,11 @@ spec:
           mountPath: /harbor_cust_cert/custom-ca-bundle.crt
           subPath: ca.crt
         {{- end }}
+        {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "gcs") }}
+        - name: gcs-key
+          mountPath: /etc/registry/gcs-key.json
+          subPath: gcs-key.json
+        {{- end }}
       volumes:
       - name: registry-root-certificate
         secret:


### PR DESCRIPTION
Garbage collector got 500 error when using GCS to store image. The reason is because missing mount for gcs-key.json so this PR is an attempt to fix it.