### PR TITLE
Allow to overwrite registry auth

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -149,11 +149,15 @@ data:
       debug:
         addr: localhost:5001
     auth:
+    {{- if .Values.registry.auth }}
+{{ toYaml .Values.registry.auth | indent 6 }}
+    {{- else }}
       token:
         issuer: harbor-token-issuer
         realm: "{{ .Values.externalURL }}/service/token"
         rootcertbundle: /etc/registry/root.crt
         service: harbor-registry
+    {{- end }}
     validation:
       disabled: true
     notifications:

--- a/values.yaml
+++ b/values.yaml
@@ -331,6 +331,9 @@ registry:
       repository: goharbor/registry-photon
       tag: dev
 
+  # overwrite auth config of registry, defaults to harbor service token from externalURL
+  auth: {}
+
     # resources:
     #  requests:
     #    memory: 256Mi


### PR DESCRIPTION
This makes it possible to use other authentication services or another ingress for the core service to access the registry.