### PR TITLE
Add possibility for custom pod labels

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.chartmuseum.podLabels }}
+{{ toYaml .Values.chartmuseum.podLabels | indent 8 }}
+{{- end }}
         component: chartmuseum
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/chartmuseum/chartmuseum-cm.yaml") . | sha256sum }}

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.clair.podLabels }}
+{{ toYaml .Values.clair.podLabels | indent 8 }}
+{{- end }}
         component: clair
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/clair/clair-cm.yaml") . | sha256sum }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.matchLabels" . | indent 8 }}
+{{- if .Values.core.podLabels }}
+{{ toYaml .Values.core.podLabels | indent 8 }}
+{{- end }}
         component: core
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/core/core-cm.yaml") . | sha256sum }}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.database.podLabels }}
+{{ toYaml .Values.database.podLabels | indent 8 }}
+{{- end }}
         component: database
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/database/database-secret.yaml") . | sha256sum }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.jobservice.podLabels }}
+{{ toYaml .Values.jobservice.podLabels | indent 8 }}
+{{- end }}
         component: jobservice
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/jobservice/jobservice-cm.yaml") . | sha256sum }}
@@ -81,7 +84,7 @@ spec:
       - name: job-logs
         {{- if and .Values.persistence.enabled (eq .Values.jobservice.jobLogger "file") }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.persistentVolumeClaim.jobservice.existingClaim | default (include "harbor.jobservice" .) }}  
+          claimName: {{ .Values.persistence.persistentVolumeClaim.jobservice.existingClaim | default (include "harbor.jobservice" .) }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.nginx.podLabels }}
+{{ toYaml .Values.nginx.podLabels | indent 8 }}
+{{- end }}
         component: nginx
       annotations:
       {{- if not .Values.expose.tls.enabled }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.notary.podLabels }}
+{{ toYaml .Values.notary.podLabels | indent 8 }}
+{{- end }}
         component: notary-server
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/notary/notary-cm.yaml") . | sha256sum }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.notary.podLabels }}
+{{ toYaml .Values.notary.podLabels | indent 8 }}
+{{- end }}
         component: notary-signer
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/notary/notary-cm.yaml") . | sha256sum }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.matchLabels" . | indent 8 }}
+{{- if .Values.portal.podLabels }}
+{{ toYaml .Values.portal.podLabels | indent 8 }}
+{{- end }}
         component: portal
       annotations:
 {{- if .Values.portal.podAnnotations }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.redis.podLabels }}
+{{ toYaml .Values.redis.podLabels | indent 8 }}
+{{- end }}
         component: redis
 {{- if .Values.redis.podAnnotations }}
       annotations:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
+{{- if .Values.registry.podLabels }}
+{{ toYaml .Values.registry.podLabels | indent 8 }}
+{{- end }}
         component: registry
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-cm.yaml") . | sha256sum }}

--- a/values.yaml
+++ b/values.yaml
@@ -261,6 +261,8 @@ nginx:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
 
 portal:
   image:
@@ -276,6 +278,8 @@ portal:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
 
 core:
   image:
@@ -291,6 +295,8 @@ core:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
   # Secret is used when core server communicates with other components.
   # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
@@ -320,6 +326,8 @@ jobservice:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
   # Secret is used when job service communicates with other components.
   # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
@@ -350,6 +358,8 @@ registry:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
   # Secret is used to secure the upload state from client
   # and registry storage backend.
   # See: https://github.com/docker/distribution/blob/master/docs/configuration.md#http
@@ -374,6 +384,8 @@ chartmuseum:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
 
 clair:
   enabled: true
@@ -396,6 +408,8 @@ clair:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
 
 notary:
   enabled: true
@@ -422,6 +436,8 @@ notary:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
   # Fill the name of a kubernetes secret if you want to use your own
   # TLS certificate authority, certificate and private key for notary
   # communications.
@@ -459,6 +475,8 @@ database:
     sslmode: "disable"
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}
 
 redis:
   # if external Redis is used, set "type" to "external"
@@ -487,3 +505,5 @@ redis:
     password: ""
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional deployment labels
+  podLabels: {}


### PR DESCRIPTION
Adds the possibility to add custom pod labels for people who like to use the kubernetes recommended labels like here:
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Reason being NetworkPolicies that could be set as a default inside a namespace that wants to attach to some label. Users should have the possibility to set such label in the values directly