### PR TITLE
Correct permissions and path for notary cert

### DIFF
--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -49,8 +49,7 @@ spec:
           subPath: tls.crt
         {{- if .Values.notary.secretName }}
         - name: notary-ca
-          mountPath: /etc/ssl/notary/cert/notary-signer-ca.crt
-          subPath: ca
+          mountPath: /etc/ssl/notary/cert/
         {{- end }}
       volumes:
       - name: notary-config
@@ -67,6 +66,10 @@ spec:
       - name: notary-ca
         secret:
           secretName: {{ .Values.notary.secretName }}
+          defaultMode: 0444
+          items:
+          - key: ca.crt
+            path: notary-signer-ca.crt
       {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -44,14 +44,7 @@ spec:
           mountPath: /etc/notary
         {{- if .Values.notary.secretName }}
         - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer-ca.crt
-          subPath: ca
-        - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer.crt
-          subPath: crt
-        - name: notary-cert
-          mountPath: /etc/ssl/notary/cert/notary-signer.key
-          subPath: key
+          mountPath: /etc/ssl/notary/cert/
         {{- end }}
       volumes:
       - name: notary-config
@@ -61,6 +54,14 @@ spec:
       - name: notary-cert
         secret:
           secretName: {{ .Values.notary.secretName }}
+          defaultMode: 0444
+          items:
+          - key: ca.crt
+            path: notary-signer-ca.crt
+          - key: tls.crt
+            path: notary-signer.crt
+          - key: tls.key
+            path: notary-signer.key
       {{- end }}
     {{- with .Values.notary.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
due to the nature of how the mounts were done before the path of e.g `/etc/ssl/notary/cert/notary-signer-ca.crt` could end up as a directory with the subPath as a file inside of it.
Notary container is then unable to start up correctly since it is detecting the needed cert file as a directory.

This pr fixes this and also sets the permissions of 0444 so no one is able to tinker with the certificate inside of the container.