### PR TITLE
Allow setting IP for loadBalancer  -- 1.1 branch

### DIFF
--- a/templates/nginx/service.yaml
+++ b/templates/nginx/service.yaml
@@ -61,6 +61,9 @@ spec:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   type: LoadBalancer
+  {{- if $loadBalancer.IP }}
+  loadBalancerIP: {{ $loadBalancer.IP }}
+  {{- end }}
   ports:
     - name: http
       port: {{ $loadBalancer.ports.httpPort }}

--- a/values.yaml
+++ b/values.yaml
@@ -71,6 +71,8 @@ expose:
   loadBalancer:
     # The name of LoadBalancer service
     name: harbor
+    # Set the IP if the LoadBalancer supports assigning IP
+    IP: ""
     ports:
       # The service port Harbor listens on when serving with HTTP
       httpPort: 80


### PR DESCRIPTION
This commit add the IP field to expose.loadBalancer, which will be set
to the service of nginx pod

Signed-off-by: Daniel Jiang <jiangd@vmware.com>