### PR TITLE
Fix removing /var/lib/postgresql/data/lost+found part

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -33,7 +33,7 @@ spec:
       - name: "remove-lost-found"
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        command: ["rm", "-Rf", "/var/lib/postgresql/data/lost+found"]
+        command: ["/bin/bash","-c","rm -Rf /var/lib/postgresql/data/lost+found || true"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
Fix removing `/var/lib/postgresql/data/lost+found` when it doesn't exist.

The init container `remove-lost-found` will be restarted indefinitely when the `directory /var/lib/postgresql/data/lost+found` doesn't exist:

```bash
$ kubectl describe pod -n harbor harbor-harbor-database-0 
Name:               harbor-harbor-database-0
Namespace:          harbor
Priority:           0
PriorityClassName:  <none>
Node:               aks-cluster1-83325338-2/10.240.0.5
Start Time:         Mon, 12 Aug 2019 15:58:31 +0200
Labels:             app=harbor
                    chart=harbor
                    component=database
                    controller-revision-hash=harbor-harbor-database-9565ddb96
                    heritage=Tiller
                    release=harbor
                    statefulset.kubernetes.io/pod-name=harbor-harbor-database-0
Annotations:        checksum/secret: 8accf53dfbf601db7e1b0fb79823d057c19b43014181ecc32c20f049f948b187
Status:             Pending
IP:                 10.244.1.128
Controlled By:      StatefulSet/harbor-harbor-database
Init Containers:
  remove-lost-found:
    Container ID:  docker://95c2f789d5d8e2d2abc336e2bca9cd78dee869fcc61cbe37de42ff487d18bab3
    Image:         goharbor/harbor-db:dev
    Image ID:      docker-pullable://goharbor/harbor-db@sha256:a82df267989bef641dbc16036b044b9f4973b37b750130ed27809edb714208bb
    Port:          <none>
    Host Port:     <none>
    Command:
      rm
      -Rf
      /var/lib/postgresql/data/lost+found
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Mon, 12 Aug 2019 16:25:35 +0200
      Finished:     Mon, 12 Aug 2019 16:25:35 +0200
    Ready:          False
    Restart Count:  10
    Environment:    <none>
    Mounts:
      /var/lib/postgresql/data from database-data (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-nns82 (ro)
Containers:
  database:
    Container ID:   
    Image:          goharbor/harbor-db:dev
    Image ID:
    Port:           <none>
    Host Port:      <none>
    State:          Waiting
      Reason:       PodInitializing
    Ready:          False
    Restart Count:  0
    Liveness:       exec [/docker-healthcheck.sh] delay=60s timeout=1s period=10s #success=1 #failure=3
    Readiness:      exec [/docker-healthcheck.sh] delay=1s timeout=1s period=10s #success=1 #failure=3
    Environment Variables from:
      harbor-harbor-database  Secret  Optional: false
    Environment:              <none>
    Mounts:
      /var/lib/postgresql/data from database-data (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-nns82 (ro)
Conditions:
  Type              Status
  Initialized       False
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  database-data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  database-data-harbor-harbor-database-0
    ReadOnly:   false
  default-token-nns82:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-nns82
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type     Reason                  Age                    From                              Message
  ----     ------                  ----                   ----                              -------
  Warning  FailedScheduling        29m (x5 over 29m)      default-scheduler                 pod has unbound immediate PersistentVolumeClaims (repeated 5 times)
  Normal   Scheduled               29m                    default-scheduler                 Successfully assigned harbor/harbor-harbor-database-0 to aks-cluster1-83325338-2
  Normal   SuccessfulAttachVolume  28m                    attachdetach-controller           AttachVolume.Attach succeeded for volume "pvc-30e9987d-bd09-11e9-b9e9-fe195c1ab2e3"
  Normal   Pulling                 28m                    kubelet, aks-cluster1-83325338-2  Pulling image "goharbor/harbor-db:dev"
  Normal   Pulled                  28m                    kubelet, aks-cluster1-83325338-2  Successfully pulled image "goharbor/harbor-db:dev"
  Normal   Pulled                  26m (x4 over 28m)      kubelet, aks-cluster1-83325338-2  Container image "goharbor/harbor-db:dev" already present on machine
  Normal   Created                 26m (x5 over 28m)      kubelet, aks-cluster1-83325338-2  Created container remove-lost-found
  Normal   Started                 26m (x5 over 28m)      kubelet, aks-cluster1-83325338-2  Started container remove-lost-found
  Warning  BackOff                 3m26s (x116 over 28m)  kubelet, aks-cluster1-83325338-2  Back-off restarting failed container
```