### PR TITLE
Refactor the assignment logic to support old version of helm

### DIFF
--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -40,24 +40,24 @@ spec:
       - name: nginx
         image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-        {{- $scheme := "HTTP" }}
-        {{- $port := 8080 }}
+        {{- $_ := set . "scheme" "HTTP" -}}
+        {{- $_ := set . "port" "8080" -}}
         {{- if .Values.expose.tls.enabled }}
-          {{- $scheme = "HTTPS" }}
-          {{- $port = 8443 }}
+          {{- $_ := set . "scheme" "HTTPS" -}}
+          {{- $_ := set . "port" "8443" -}}
         {{- end }}
         livenessProbe:
           httpGet:
-            scheme: {{ $scheme }}
+            scheme: {{ .scheme }}
             path: /
-            port: {{ $port }}
+            port: {{ .port }}
           initialDelaySeconds: 1
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            scheme: {{ $scheme }}
+            scheme: {{ .scheme }}
             path: /
-            port: {{ $port }}
+            port: {{ .port }}
           initialDelaySeconds: 1
           periodSeconds: 10
 {{- if .Values.nginx.resources }}


### PR DESCRIPTION
Helm <= 2.10 doesn't support the assignment of a value to a variable defined in a different scope, refactor the logic to support the helm client whose version <= 2.10

Signed-off-by: Wenkai Yin <yinw@vmware.com>