### PR TITLE
add support for AWS S3 Server Side Encryption

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -65,6 +65,9 @@ data:
   {{- if $storage.s3.accesskey }}
   AWS_ACCESS_KEY_ID: {{ $storage.s3.accesskey }}
   {{- end }}
+  {{- if $storage.s3.keyid }}
+  STORAGE_AMAZON_SSE: aws:kms
+  {{- end }}
 {{- else if eq $storageType "swift" }}
   STORAGE: "openstack"
   STORAGE_OPENSTACK_CONTAINER: {{ $storage.swift.container }}

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -47,6 +47,9 @@ data:
         {{- if $storage.s3.encrypt }}
         encrypt: {{ $storage.s3.encrypt }}
         {{- end }}
+        {{- if $storage.s3.keyid }}
+        keyid: {{ $storage.s3.keyid }}
+        {{- end }}
         {{- if $storage.s3.secure }}
         secure: {{ $storage.s3.secure }}
         {{- end }}


### PR DESCRIPTION
This commit adds support for AWS S3 SSE for registry and chartmuseum. It's already defined in values file (see "keyid").