### PR TITLE
ingress: "nosecret" option

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app: "{{ template "harbor.name" . }}"
 {{- end -}}
 
 {{- define "harbor.autoGenCertForIngress" -}}
-  {{- if and (eq (include "harbor.autoGenCert" .) "true") (eq .Values.expose.type "ingress") -}}
+  {{- if and (eq (include "harbor.autoGenCert" .) "true") (eq .Values.expose.type "ingress") (not .Values.expose.ingress.nosecret) (not .Values.expose.ingress.notaryNoSecret) -}}
     {{- printf "true" -}}
   {{- else -}}
     {{- printf "false" -}}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -74,7 +74,7 @@ spec:
         - name: token-service-private-key
           mountPath: /etc/core/private_key.pem
           subPath: tls.key
-        {{- if .Values.expose.tls.enabled }}
+        {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
         - name: ca-download
           mountPath: /etc/core/ca
         {{- end }}
@@ -109,7 +109,7 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.core" . }}
           {{- end }}
-      {{- if .Values.expose.tls.enabled }}
+      {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
       - name: ca-download
         secret:
         {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -34,6 +34,12 @@ metadata:
 spec:
   {{- if $tls.enabled }}
   tls:
+    {{- if $ingress.nosecret }}
+    {{- if $ingress.hosts.core }}
+  - hosts:
+    - {{ $ingress.hosts.core }}
+    {{- end }}
+    {{- else }}
     {{- if $tls.secretName }}
   - secretName: {{ $tls.secretName }}
     {{- else }}
@@ -43,7 +49,14 @@ spec:
     hosts:
     - {{ $ingress.hosts.core }}
     {{- end }}
+    {{- end }}
   {{- if .Values.notary.enabled }}
+    {{- if $ingress.notaryNoSecret }}
+    {{- if $ingress.hosts.notary }}
+  - hosts:
+    - {{ $ingress.hosts.notary }}
+    {{- end }}
+    {{- else }}
     {{- if $tls.notarySecretName }}
   - secretName: {{ $tls.notarySecretName }}
     {{- else if $tls.secretName }}
@@ -54,6 +67,7 @@ spec:
     {{- if $ingress.hosts.notary }}
     hosts:
     - {{ $ingress.hosts.notary }}
+    {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,14 @@ expose:
     # set to `gce` if using the GCE ingress controller
     # set to `ncp` if using the NCP (NSX-T Container Plugin) ingress controller
     controller: default
+    # You can specify that you want no secret in the ingress's TLS section.
+    # In this case, the "secretName" option will be ignored.
+    # This is useful for setups where the ingress controller already provides
+    # a TLS secret for multiple or all ingresses in the cluster.
+    nosecret: false
+    # The same setting for the notary ingress, if the notary is enabled.
+    # If set, notarySecretName will be ignored.
+    notaryNoSecret: false
     annotations:
       ingress.kubernetes.io/ssl-redirect: "true"
       ingress.kubernetes.io/proxy-body-size: "0"


### PR DESCRIPTION
This adds an option to leave out the "secretName" setting in the tls section of generated ingress resources. This is useful for setups where the ingress controller already provides a default TLS secret for multiple or all ingresses in the cluster, which is supported e.g. by the nginx-ingress-controller via its `--default-ssl-certificate` option.