### PR TITLE
Proxy support for registry synching

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -46,6 +46,16 @@ spec:
         - secretRef:
             name: "{{ template "harbor.core" . }}"
         env:
+          {{- if .Values.httpProxy }}
+          - name: HTTP_PROXY
+            value: {{ .Values.httpProxy }}
+          {{- end }}
+          {{- if .Values.httpsProxy }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.httpsProxy }}
+          {{- end }}
+          - name: NO_PROXY
+            value: "{{ template "harbor.registry" . }},{{ template "harbor.core" . }},{{ template "harbor.portal" . }},{{ template "harbor.database" . }},{{ template "harbor.redis" . }},{{ template "harbor.jobservice" . }}"
           - name: CORE_SECRET
             valueFrom:
               secretKeyRef:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -61,6 +61,16 @@ spec:
             value: "http://{{ template "harbor.registry" . }}:8080"
           - name: LOG_LEVEL
             value: debug
+          {{- if .Values.httpProxy }}
+          - name: HTTP_PROXY
+            value: {{ .Values.httpProxy }}
+          {{- end }}
+          {{- if .Values.httpsProxy }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.httpsProxy }}
+          {{- end }}
+          - name: NO_PROXY
+            value: "{{ template "harbor.registry" . }},{{ template "harbor.core" . }}"
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -233,6 +233,10 @@ harborAdminPassword: "Harbor12345"
 # The secret key used for encryption. Must be a string of 16 chars.
 secretKey: "not-a-secure-key"
 
+#proxy if needed for registry sync. Sets proxy on jobservice and core
+#httpProxy:
+#httpsProxy:
+
 # If expose the service via "ingress", the Nginx will not be used
 nginx:
   image:
@@ -312,6 +316,7 @@ jobservice:
   # Must be a string of 16 chars.
   secret: ""
 
+  
 registry:
   registry:
     image:


### PR DESCRIPTION
Adds support for having harbor behind proxy and do registry synchronization towards other registry where access is restricted to only use a proxy.

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>