### PR TITLE
[Cherry-pick]Mount the certificate of UAA in a seperated directory

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -49,7 +49,7 @@ data:
   REGISTRYCTL_URL: "http://{{ template "harbor.registry" . }}:8080"
   CLAIR_HEALTH_CHECK_SERVER_URL: "http://{{ template "harbor.clair" . }}:6061"
   {{- if .Values.uaaSecretName }}
-  UAA_CA_ROOT: "/etc/core/ca/auth-ca.crt"
+  UAA_CA_ROOT: "/etc/core/auth-ca/auth-ca.crt"
   {{- end }}
   {{- if has "core" .Values.proxy.components }}
   HTTP_PROXY: "{{ .Values.proxy.httpProxy }}"

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -80,7 +80,7 @@ spec:
         {{- end }}
         {{- if .Values.uaaSecretName }}
         - name: auth-ca-cert
-          mountPath: /etc/core/ca/auth-ca.crt
+          mountPath: /etc/core/auth-ca/auth-ca.crt
           subPath: auth-ca.crt
         {{- end }}
         - name: psc


### PR DESCRIPTION
Fixes #378, mount the certificate of UAA in a seperated directory

Signed-off-by: Wenkai Yin <yinw@vmware.com>