### PR TITLE
Remove notifier section from clair conf file

### DIFF
--- a/conf/clair.yaml
+++ b/conf/clair.yaml
@@ -14,8 +14,3 @@ clair:
     timeout: 300s
   updater:
     interval: {{ .Values.clair.updatersInterval }}h
-  notifier:
-    attempts: 3
-    renotifyinterval: 2h
-    http:
-      endpoint: "http://{{ template "harbor.core" . }}/service/notifications/clair"


### PR DESCRIPTION
This commit make remove notifier from configuration file of clair in the chart to
make sure it's consistent with Harbor 1.9

Signed-off-by: Daniel Jiang <jiangd@vmware.com>