### PR TITLE
[Cherry-pick-1.2]Extend the initialDelaySeconds of livenessProbe

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -37,7 +37,7 @@ spec:
           httpGet:
             path: /health
             port: 9999
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -35,7 +35,7 @@ spec:
           httpGet:
             path: /health
             port: 6061
-          initialDelaySeconds: 30
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -55,7 +55,7 @@ spec:
           exec:
             command:
             - /docker-healthcheck.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           exec:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -38,7 +38,7 @@ spec:
           httpGet:
             path: /api/v1/stats
             port: 8080
-          initialDelaySeconds: 20
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             scheme: {{ .scheme }}
             path: /
             port: {{ .port }}
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           httpGet:
             path: /
             port: 8080
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6379
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           tcpSocket:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -37,7 +37,7 @@ spec:
           httpGet:
             path: /
             port: 5000
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:
@@ -90,7 +90,7 @@ spec:
           httpGet:
             path: /api/health
             port: 8080
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:


### PR DESCRIPTION
This commits extends the initialDelaySeconds of livenessProbe to avoild pod creating failure when the pod starting up slowly

Signed-off-by: Wenkai Yin <yinw@vmware.com>