### PR TITLE
[Cherry-pick-1.1]Extend the initialDelaySeconds of livenessProbe

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -33,7 +33,7 @@ spec:
           httpGet:
             path: /health
             port: 9999
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -31,7 +31,7 @@ spec:
           httpGet:
             path: /health
             port: 6061
-          initialDelaySeconds: 30
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -41,7 +41,7 @@ spec:
           exec:
             command:
             - /docker-healthcheck.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           exec:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -32,7 +32,7 @@ spec:
           httpGet:
             path: /api/v1/stats
             port: 8080
-          initialDelaySeconds: 20
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           httpGet:
             path: /
             port: 80
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           httpGet:
             path: /
             port: 80
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6379
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           tcpSocket:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -33,7 +33,7 @@ spec:
           httpGet:
             path: /
             port: 5000
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:
@@ -74,7 +74,7 @@ spec:
           httpGet:
             path: /api/health
             port: 8080
-          initialDelaySeconds: 1
+          initialDelaySeconds: 300
           periodSeconds: 10
         readinessProbe:
           httpGet:


### PR DESCRIPTION
This commits extends the initialDelaySeconds of livenessProbe to avoild pod creating failure when the pod starting up slowly

Signed-off-by: Wenkai Yin <yinw@vmware.com>