### PR TITLE
allow chartmuseum to use Azure storage accounts in non-public Azure c…

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -44,6 +44,7 @@ data:
   STORAGE: "microsoft"
   STORAGE_MICROSOFT_CONTAINER: {{ $storage.azure.container }}
   AZURE_STORAGE_ACCOUNT: {{ $storage.azure.accountname }}
+  AZURE_BASE_URL: {{ $storage.azure.realm }}
   STORAGE_MICROSOFT_PREFIX: "/azure/harbor/charts"
 {{- else if eq $storageType "gcs" }}
   STORAGE: "google"


### PR DESCRIPTION
The Azure storage realm (base URL) is being defined and applied to the registry storage configuration, but not the chartmuseum configuration.  This PR allows chartmuseum to use Azure storage in non-public (government) Azure cloud environments. 