### PR TITLE
Template database init container image for 'change-permission-of-directory'

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       initContainers:
       - name: "change-permission-of-directory"
-        image: "busybox:latest"
+        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
         args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -33,8 +33,7 @@ spec:
       - name: "change-permission-of-directory"
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        command: ["/bin/sh"]
-        args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]
+        args: ["chown", "-R", "999:999", "/var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
* Allows for disconnected/offline installs

Cannot currently install harbor from an offline harbor repository without access to pull upstream container 'busybox:latest' (or pre-caching same on hosts)

* Reuses existing harbor database container by default

As init container is only executing chown, the existing database image should suffice for the init container, reducing the number of required images.