### PR TITLE
Removing typo '}' from ingress.annotations default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `expose.loadBalancer.ports.httpPort` | The service port Harbor listens on when serving with HTTP |`80`|
 | `expose.loadBalancer.ports.httpsPort` | The service port Harbor listens on when serving with HTTP |`30002`|
 | `expose.loadBalancer.ports.notaryPort` | The service port Notary listens on. Only needed when `notary.enabled` is set to `true`|
-| `expose.loadBalancer.annotations` | The annotations attached to the loadBalancer service | {}} |
+| `expose.loadBalancer.annotations` | The annotations attached to the loadBalancer service | {} |
 | `expose.loadBalancer.sourceRanges` | List of IP address ranges to assign to loadBalancerSourceRanges | [] |
 | **Persistence**                                                             |
 | `persistence.enabled`                                                       | Enable the data persistence or not                                                                                                                                                                                                                                                                                                              | `true`                          |


### PR DESCRIPTION
Editing`{}}` to `{}` for the default annotation value.