### PR TITLE
Update the image tags to 1.9.4-dev for chart 1.2.x

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -268,7 +268,7 @@ proxy:
 nginx:
   image:
     repository: goharbor/nginx-photon
-    tag: v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
   # resources:
   #  requests:
@@ -283,7 +283,7 @@ nginx:
 portal:
   image:
     repository: goharbor/harbor-portal
-    tag: v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
 # resources:
 #  requests:
@@ -298,7 +298,7 @@ portal:
 core:
   image:
     repository: goharbor/harbor-core
-    tag: v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
   ## Liveness probe values
   livenessProbe:
@@ -327,7 +327,7 @@ core:
 jobservice:
   image:
     repository: goharbor/harbor-jobservice
-    tag: v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
@@ -350,7 +350,7 @@ registry:
   registry:
     image:
       repository: goharbor/registry-photon
-      tag: v2.7.1-patch-2819-2553-v1.9.3
+      tag: v1.9.4-dev
 
     # resources:
     #  requests:
@@ -359,7 +359,7 @@ registry:
   controller:
     image:
       repository: goharbor/harbor-registryctl
-      tag: v1.9.3
+      tag: v1.9.4-dev
 
     # resources:
     #  requests:
@@ -397,7 +397,7 @@ chartmuseum:
   absoluteUrl: false
   image:
     repository: goharbor/chartmuseum-photon
-    tag: v0.9.0-v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
   # resources:
   #  requests:
@@ -413,7 +413,7 @@ clair:
   enabled: true
   image:
     repository: goharbor/clair-photon
-    tag: v2.1.0-v1.9.3
+    tag: v1.9.4-dev
   replicas: 1
   # The interval of clair updaters, the unit is hour, set to 0 to
   # disable the updaters
@@ -433,7 +433,7 @@ notary:
   server:
     image:
       repository: goharbor/notary-server-photon
-      tag: v0.6.1-v1.9.3
+      tag: v1.9.4-dev
     replicas: 1
     # resources:
     #  requests:
@@ -442,7 +442,7 @@ notary:
   signer:
     image:
       repository: goharbor/notary-signer-photon
-      tag: v0.6.1-v1.9.3
+      tag: v1.9.4-dev
     replicas: 1
     # resources:
     #  requests:
@@ -468,7 +468,7 @@ database:
   internal:
     image:
       repository: goharbor/harbor-db
-      tag: v1.9.3
+      tag: v1.9.4-dev
     # The initial superuser password for internal database
     password: "changeit"
     # resources:
@@ -512,7 +512,7 @@ redis:
   internal:
     image:
       repository: goharbor/redis-photon
-      tag: v1.9.3
+      tag: v1.9.4-dev
     # resources:
     #  requests:
     #    memory: 256Mi


### PR DESCRIPTION
This commit makes sure we can run ci on pipeline to verify latest code
on 1.9 branch.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>