### PR TITLE
add support for traefik ingressroute

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -317,6 +317,10 @@ host:port,pool_size,password
   {{- printf "%s-ingress" (include "harbor.fullname" .) -}}
 {{- end -}}
 
+{{- define "harbor.ingressRoute" -}}
+  {{- printf "%s-ingressroute" (include "harbor.fullname" .) -}}
+{{- end -}}
+
 {{- define "harbor.noProxy" -}}
   {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) .Values.proxy.noProxy -}}
 {{- end -}}

--- a/templates/ingress/ingressroute.yaml
+++ b/templates/ingress/ingressroute.yaml
@@ -1,0 +1,47 @@
+{{- if eq .Values.expose.type "ingressRoute" }}
+{{- $ingressRoute := .Values.expose.ingressRoute -}}
+{{- $_ := set . "portal_path" "/" -}}
+{{- $_ := set . "api_path" "/api/" -}}
+{{- $_ := set . "service_path" "/service/" -}}
+{{- $_ := set . "v2_path" "/v2/" -}}
+{{- $_ := set . "chartrepo_path" "/chartrepo/" -}}
+{{- $_ := set . "controller_path" "/c/" -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: "{{ template "harbor.ingressRoute" . }}"
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+{{- if $ingressRoute.annotations }}
+  annotations:
+{{ toYaml $ingressRoute.annotations | indent 4 }}
+{{- end }}
+spec:
+  entryPoints:
+{{ toYaml $ingressRoute.entryPoints | indent 2 }}
+  routes:
+  - kind: Rule
+    match: Host(`{{ $ingressRoute.hosts.core }}`)
+    services:
+    - kind: Service
+      name: {{ template "harbor.portal" . }}
+      port: 80
+  - kind: Rule
+    match: Host(`{{ $ingressRoute.hosts.core }}`) && (PathPrefix(`{{ .api_path }}`) || PathPrefix(`{{ .service_path }}`) || PathPrefix(`{{ .v2_path }}`) || PathPrefix(`{{ .chartrepo_path }}`) || PathPrefix(`{{ .controller_path }}`))
+    services:
+    - kind: Service
+      name: {{ template "harbor.core" . }}
+      port: 80
+  {{- if .Values.notary.enabled }}
+  - kind: Rule
+    match: Host(`{{ $ingressRoute.hosts.notary }}`)
+    services:
+    - kind: Service
+      name: {{ template "harbor.notary-server" . }}
+      port: 4443
+  {{- end }}
+{{- if $ingressRoute.tls }}
+  tls: 
+{{ toYaml $ingressRoute.tls | indent 4 }}
+{{- end }}
+{{- end }}

--- a/templates/nginx/configmap-http.yaml
+++ b/templates/nginx/configmap-http.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.expose.type "ingress") (not .Values.expose.tls.enabled) }}
+{{- if and (and (ne .Values.expose.type "ingress") (ne .Values.expose.type "ingressRoute")) (not .Values.expose.tls.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -139,4 +139,3 @@ data:
       }
     }
 {{- end }}
-    

--- a/templates/nginx/configmap-https.yaml
+++ b/templates/nginx/configmap-https.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.expose.type "ingress") .Values.expose.tls.enabled }}
+{{- if and (and (ne .Values.expose.type "ingress") (ne .Values.expose.type "ingressRoute")) .Values.expose.tls.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -210,4 +210,3 @@ data:
       } 
     }
 {{- end }}
-    

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.expose.type "ingress" }}
+{{- if and (ne .Values.expose.type "ingress") (ne .Values.expose.type "ingressRoute") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,14 @@ expose:
       ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  ingressRoute:
+    hosts:
+      core: core.harbor.domain
+      notary: notary.harbor.domain
+    annotations: {}
+    entryPoints: []
+    middlewares: []
+    tls: {}
   clusterIP:
     # The name of ClusterIP service
     name: harbor


### PR DESCRIPTION
This PR adds support for the [Traefik IngressRoute CRD](https://docs.traefik.io/v2.0/providers/kubernetes-crd/) as a method of ingressing traffic to Harbor.  

I was having trouble uploading layers to Harbor, getting an `unkown blob` 500 internal server error. Reading through the Harbor issues, that seems to show up when there's an HTTPS terminating proxy in front of the NGINX Harbor proxy, but even following the [troublshooting steps for this double proxy scenario](https://github.com/goharbor/harbor/blob/master/docs/installation_guide.md#using-nginx-or-load-balancing) I was not able to get Harbor to work behind Traefik. Since Traefik is doing what the NGINX is doing, but using the IngressRoute CRD instead of the Ingress object in this configuration, I thought it might be cleanest to enable direct Traefik CRD integrations.