### PR TITLE
Add missed '$' in nginx config map -cherrypick 1.3

### DIFF
--- a/templates/nginx/configmap-https.yaml
+++ b/templates/nginx/configmap-https.yaml
@@ -41,7 +41,7 @@ data:
       }
       {{- end }}
       
-      log_format timed_combined 'remote_addr - '
+      log_format timed_combined '$remote_addr - '
         '"$request" $status $body_bytes_sent '
         '"$http_referer" "$http_user_agent" '
         '$request_time $upstream_response_time $pipe';


### PR DESCRIPTION
Signed-off-by: Daniel Jiang <jiangd@vmware.com>