### PR TITLE
fix bugs that postgres can't start

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -33,8 +33,12 @@ spec:
       - name: "change-permission-of-directory"
         image: {{ .Values.database.internal.initContainerImage.repository }}:{{ .Values.database.internal.initContainerImage.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        command: ["/bin/sh"]
-        args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]
+        command:
+          - /bin/sh
+          - -c
+          - |
+            chown -R 999:999 /var/lib/postgresql/data
+            chmod 700 /var/lib/postgresql/data
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
after k8s node restart, the postgres of harbor can't restart. It's file mode issue when checking logs
```
kubectl logs -f harbor-sh-harbor-database-0 -n harbor-sh
FATAL:  data directory "/var/lib/postgresql/data" has group or world access
DETAIL:  Permissions should be u=rwx (0700).
```
I find a method that change the config of initContainers to fix the bug. I Also found in https://github.com/helm/charts Postgres are configured with master-slave, hoping to use asap,  I also can help if is needed.

FYI:
https://github.com/ClusterHQ/dvol/issues/45
https://github.com/helm/charts/tree/master/stable/postgresql

