### PR TITLE
Support externally-managed serviceAccounts for registry and chartmuseum for IRSA

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -36,6 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ .Values.chartmuseum.serviceAccount.name . }}
       containers:
       - name: chartmuseum
         image: {{ .Values.chartmuseum.image.repository }}:{{ .Values.chartmuseum.image.tag }}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.chartmuseum.serviceAccount.name . }}
+      serviceAccountName: {{ .Values.chartmuseum.serviceAccount.name }}
       containers:
       - name: chartmuseum
         image: {{ .Values.chartmuseum.image.repository }}:{{ .Values.chartmuseum.image.tag }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -36,6 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ .Values.registry.serviceAccount.name . }}
       containers:
       - name: registry
         image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.registry.serviceAccount.name . }}
+      serviceAccountName: {{ .Values.registry.serviceAccount.name }}
       containers:
       - name: registry
         image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}

--- a/values.yaml
+++ b/values.yaml
@@ -379,6 +379,9 @@ registry:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Optionally specify custom service account managed outside this chart
+  serviceAccount:
+    name: 
   ## Additional deployment annotations
   podAnnotations: {}
   # Secret is used to secure the upload state from client
@@ -416,6 +419,9 @@ chartmuseum:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Optionally specify custom service account managed outside this chart
+  serviceAccount:
+    name: 
   ## Additional deployment annotations
   podAnnotations: {}
 


### PR DESCRIPTION
When running Harbor on EKS and using S3 for Registry and Chartmuseum there is an opportunity to manage AWS credentials using "IAM Roles for Service Accounts" (IRSA). The upstream Registry and Chartmuseum projects don't yet have working IRSA support but it's just around the corner! I've tested this PR against our forks of those projects (using Harbor's build process for them) and using Service Accounts managed outside of helm I'm able to use AWS S3 as the storage provider without explicit credentials or running KIAM/Kube2IAM.