### PR TITLE
Edited log level comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `imagePullPolicy` | The image pull policy |  |
 | `imagePullSecrets` | The imagePullSecrets names for all deployments |  |
 | `updateStrategy.type` | The update strategy for deployments with persistent volumes(jobservice, registry and chartmuseum): `RollingUpdate` or `Recreate`. Set it as `Recreate` when `RWM` for volumes isn't supported  | `RollingUpdate` |
-| `logLevel` | The log level: `debug`, `info`, `warning`, `error` or `fatal` | `info` |
+| `logLevel` | The log level: `debug`, `info`, `warn` or `error` | `info` |
 | `harborAdminPassword`                                                       | The initial password of Harbor admin. Change it from portal after launching Harbor                                                                                                                                                                                                                                                              | `Harbor12345`                   |
 | `secretkey`                                                                 | The key used for encryption. Must be a string of 16 chars                                                                                                                                                                                                                                                                                       | `not-a-secure-key`              |
 | `proxy.httpProxy` | The URL of the HTTP proxy server | |

--- a/values.yaml
+++ b/values.yaml
@@ -246,7 +246,7 @@ imagePullSecrets:
 updateStrategy:
   type: RollingUpdate
 
-# debug, info, warning, error or fatal
+# debug, info, warn or error
 logLevel: info
 
 # The initial password of Harbor admin. Change it from portal after launching Harbor


### PR DESCRIPTION
When logLevel set to warning as described in comment on values.yaml, registry container failing with _'Invalid logLevel warning Must be one of [error, warn, info, debug]'_ error. Also same error occuring when logLevel setted to 'fatal'.