### PR TITLE
Add CA bundle to Clair

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -54,6 +54,14 @@ app: "{{ template "harbor.name" . }}"
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.caBundleMountPath" -}}
+  {{- printf "/harbor_cust_cert/custom-ca-bundle.crt" -}}
+{{- end -}}
+
+{{- define "harbor.caBundleSubPath" -}}
+  {{- printf "ca.crt" -}}
+{{- end -}}
+
 {{- define "harbor.database.host" -}}
   {{- if eq .Values.database.type "internal" -}}
     {{- template "harbor.database" . }}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -116,8 +116,8 @@ spec:
         {{- end }}
         {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
         - name: storage-service-ca
-          mountPath: /harbor_cust_cert/custom-ca-bundle.crt
-          subPath: ca.crt
+          mountPath: {{ template "harbor.caBundleMountPath" . }}
+          subPath: {{ template "harbor.caBundleSubPath" . }}
         {{- end }}
       volumes:
       - name: chartmuseum-data

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -81,6 +81,11 @@ spec:
           mountPath: /etc/harbor/ssl/clair_adapter.key
           subPath: tls.key
         {{- end }}
+        {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
+        - name: storage-service-ca
+          mountPath: {{ template "harbor.caBundleMountPath" . }}
+          subPath: {{ template "harbor.caBundleSubPath" . }}
+        {{- end }}
       - name: adapter
         image: {{ .Values.clair.adapter.image.repository }}:{{ .Values.clair.adapter.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -150,6 +155,11 @@ spec:
       - name: clair-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.clair.secretName" . }}
+      {{- end }}
+      {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
+      - name: storage-service-ca
+        secret:
+          secretName: {{ .Values.persistence.imageChartStorage.caBundleSecretName }}
       {{- end }}
     {{- with .Values.clair.nodeSelector }}
       nodeSelector:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -120,8 +120,8 @@ spec:
         {{- end }}
         {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
         - name: storage-service-ca
-          mountPath: /harbor_cust_cert/custom-ca-bundle.crt
-          subPath: ca.crt
+          mountPath: {{ template "harbor.caBundleMountPath" . }}
+          subPath: {{ template "harbor.caBundleSubPath" . }}
         {{- end }}
         {{- if .Values.registry.middleware.enabled }}
         {{- if eq .Values.registry.middleware.type "cloudFront" }}
@@ -201,8 +201,8 @@ spec:
         {{- end }}
         {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
         - name: storage-service-ca
-          mountPath: /harbor_cust_cert/custom-ca-bundle.crt
-          subPath: ca.crt
+          mountPath: {{ template "harbor.caBundleMountPath" . }}
+          subPath: {{ template "harbor.caBundleSubPath" . }}
         {{- end }}
         {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "gcs") }}
         - name: gcs-key


### PR DESCRIPTION
Enable end-user to use Clair via corporate MITM proxy.

Enhancement: extract CA bundle related variables into helper function

Fixes #529

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

**Special notes for your reviewer**:
Reused the already existing CA Bundle `imageChartStorage.caBundleSecretName`, but I am happy to introduce a new variable.