### PR TITLE
fix(trivy): Encode GitHub token

### DIFF
--- a/templates/trivy/trivy-secret.yaml
+++ b/templates/trivy/trivy-secret.yaml
@@ -8,5 +8,5 @@ metadata:
 type: Opaque
 data:
   redisURL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
-  gitHubToken: {{ .Values.trivy.gitHubToken | quote }}
+  gitHubToken: {{  .Values.trivy.gitHubToken | default "" | b64enc | quote }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -486,7 +486,7 @@ trivy:
   #
   # You can create a GitHub token by following the instuctions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
-  gitHubToken:
+  gitHubToken: ""
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
We have to encode the token, otherwise it's get decoded to gibberish and fails when Trivy downloads the DB form GitHub.