### PR TITLE
Switch auth mode of registry, and other cleanup

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -12,13 +12,6 @@ data:
 
     [dev]
     httpport = 8080
-    EnableXSRF = true
-    {{- if .Values.core.xsrfKey }}
-    XSRFKey = {{ .Values.core.xsrfKey }}
-    {{- else }}
-    XSRFKey = {{ randAlphaNum 40 }}
-    {{- end }}
-    XSRFExpire = 3600
   DATABASE_TYPE: "postgresql"
   POSTGRESQL_HOST: "{{ template "harbor.database.host" . }}"
   POSTGRESQL_PORT: "{{ template "harbor.database.port" . }}"
@@ -58,6 +51,8 @@ data:
   PORTAL_URL: "http://{{ template "harbor.portal" . }}"
   REGISTRYCTL_URL: "http://{{ template "harbor.registry" . }}:8080"
   CLAIR_HEALTH_CHECK_SERVER_URL: "http://{{ template "harbor.clair" . }}:6061"
+  REGISTRY_CREDENTIAL_USERNAME: "{{ .Values.registry.credentials.username }}"
+  CSRF_KEY: "{{ randAlphaNum 32 }}"
   {{- if .Values.uaaSecretName }}
   UAA_CA_ROOT: "/etc/core/auth-ca/auth-ca.crt"
   {{- end }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -14,6 +14,7 @@ data:
 {{- end }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
+  REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
 {{- if .Values.clair.enabled }}
   CLAIR_DB_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
 {{- end }}

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -150,31 +150,12 @@ data:
       debug:
         addr: localhost:5001
     auth:
-      token:
-        issuer: harbor-token-issuer
-        realm: "{{ .Values.externalURL }}/service/token"
-        rootcertbundle: /etc/registry/root.crt
-        service: harbor-registry
+      htpasswd:
+        realm: harbor-registry-basic-realm
+        path: /etc/registry/passwd
     validation:
       disabled: true
-    notifications:
-      endpoints:
-        - name: harbor
-          disabled: false
-          url: http://{{ template "harbor.core" . }}/service/notifications
-          timeout: 3000ms
-          threshold: 5
-          backoff: 1s
-          ignoredmediatypes:
-            - application/vnd.docker.image.rootfs.diff.tar.gzip
-            - application/vnd.docker.image.rootfs.foreign.diff.tar.gzip
-            - application/vnd.oci.image.layer.v1.tar
-            - application/vnd.oci.image.layer.v1.tar+gzip
-            - application/vnd.oci.image.layer.v1.tar+zstd
-            - application/vnd.oci.image.layer.nondistributable.v1.tar
-            - application/vnd.oci.image.layer.nondistributable.v1.tar+gzip
-            - application/vnd.oci.image.layer.nondistributable.v1.tar+zstd
-            - application/octet-stream
+
     {{- if .Values.registry.middleware.enabled }}
     {{- $middleware := .Values.registry.middleware }}
     {{- $middlewareType := $middleware.type }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -79,6 +79,9 @@ spec:
         - name: registry-root-certificate
           mountPath: /etc/registry/root.crt
           subPath: tls.crt
+        - name: registry-htpasswd
+          mountPath: /etc/registry/passwd
+          subPath: passwd
         - name: registry-config
           mountPath: /etc/registry/config.yml
           subPath: config.yml
@@ -156,6 +159,12 @@ spec:
           subPath: gcs-key.json
         {{- end }}
       volumes:
+      - name: registry-htpasswd
+        secret:
+          secretName: {{ template "harbor.registry" . }}
+          items:
+            - key: REGISTRY_HTPASSWD
+              path: passwd
       - name: registry-root-certificate
         secret:
           {{- if .Values.core.secretName }}

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  REGISTRY_HTPASSWD: {{ .Values.registry.credentials.htpasswd | b64enc | quote }}
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (randAlphaNum 16) | b64enc | quote }}
   REGISTRY_REDIS_PASSWORD: {{ (include "harbor.redis.rawPassword" .) | b64enc | quote }}
   {{- $storage := .Values.persistence.imageChartStorage }}

--- a/values.yaml
+++ b/values.yaml
@@ -395,6 +395,13 @@ registry:
   secret: ""
   # If true, the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL.
   relativeurls: false
+  credentials:
+    username: "harbor_registry_user"
+    password: "harbor_registry_password"
+    # If you update the username or password of registry, make sure use cli tool htpasswd to generate the bcryp hash
+    # e.g. "htpasswd -nbC10 $username $password"
+    htpasswd: "harbor_registry_user:$apr1$8XBMIDf3$fwlkQS6AAqZFUx82.RqKg/"
+
   middleware:
     enabled: false
     type: cloudFront


### PR DESCRIPTION
This commit makes change to the chart aligning with the update in Harbor
2.0:

1. Switch auth mode of registry from token to htpasswd
2. Remove notification section of registry config
3. Disable XSRF from beego

Signed-off-by: Daniel Jiang <jiangd@vmware.com>