### PR TITLE
Fix AWS encryption for Chartmuseum

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -65,6 +65,9 @@ data:
   {{- if $storage.s3.accesskey }}
   AWS_ACCESS_KEY_ID: {{ $storage.s3.accesskey }}
   {{- end }}
+  {{- if $storage.s3.keyid }}
+  STORAGE_AMAZON_SSE: aws:kms
+  {{- end }}
 {{- else if eq $storageType "swift" }}
   STORAGE: "openstack"
   STORAGE_OPENSTACK_CONTAINER: {{ $storage.swift.container }}

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -47,6 +47,9 @@ data:
         {{- if $storage.s3.encrypt }}
         encrypt: {{ $storage.s3.encrypt }}
         {{- end }}
+        {{- if $storage.s3.keyid }}
+        keyid: {{ $storage.s3.keyid }}
+        {{- end }}
         {{- if $storage.s3.secure }}
         secure: {{ $storage.s3.secure }}
         {{- end }}


### PR DESCRIPTION
Within the current implementation, the Chartmuseum component does not operate with KMS encrypted S3 storage. If encryption is enabled for a S3 bucket:
```
persistence:
  enabled: true
  imageChartStorage:
    type: s3
    s3:
      region: "${region}"
      bucket: "${bucket}"
      accesskey: "${awsaccesskey}"
      secretkey: "${awssecretkey}"
      encrypt: true
      keyid: "${keyid}"
```

the system will throw an error if a Helm chart gets uploaded via the UI:
`AccessDenied: Access Denied status code: 403, request id: D99xxx, host id: QVIxxx`.

After applying the the patch, the Charmueseum component does work correct with encrypted S3 storage. Helm charts can be up / downloaded.