### PR TITLE
Check trivy.enabled in statefulset

### DIFF
--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.trivy.enabled }}
 {{- $trivyPVC := .Values.persistence.persistentVolumeClaim.trivy -}}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -105,3 +106,4 @@ spec:
         resources:
           requests:
             storage: {{ $trivyPVC.size | quote }}
+{{- end }}


### PR DESCRIPTION
Do not generate Trivy StatefulSet if it is not enabled

Fixes #545

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>