### PR TITLE
fix: 🐛 chartmuseum and registry aliyun oss endpoint format

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -99,7 +99,11 @@ data:
   STORAGE_ALIBABA_PREFIX: {{ $storage.oss.rootdirectory }}
   {{- end }}
   {{- if $storage.oss.endpoint }}
-  STORAGE_ALIBABA_ENDPOINT: {{ $storage.oss.endpoint }}
+  STORAGE_ALIBABA_ENDPOINT: {{ $storage.oss.endpoint | trimPrefix $storage.oss.bucket | trimPrefix "." }}
+  {{- else if $storage.oss.internal}}
+  STORAGE_ALIBABA_ENDPOINT: {{ $storage.oss.region }}-internal.aliyuncs.com
+  {{- else }}
+  STORAGE_ALIBABA_ENDPOINT: {{ $storage.oss.region }}.aliyuncs.com
   {{- end }}
   ALIBABA_CLOUD_ACCESS_KEY_ID: {{ $storage.oss.accesskeyid }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -232,6 +232,7 @@ persistence:
       accesskeysecret: accesskeysecret
       region: regionname
       bucket: bucketname
+      ### endpoint format: [bucket].[region].aliyuncs.com or [bucket].[region]-internal.aliyuncs.com
       #endpoint: endpoint
       #internal: false
       #encrypt: false


### PR DESCRIPTION
https://docs.docker.com/registry/storage-drivers/oss/

1.  `region` and `bucket` is required, you must set the value in `values.yaml`.
`endpoint` default is empty
so when the `endpoint` is empty, chartmuseum will get the empty endpoint.

https://github.com/goharbor/harbor-helm/blob/55598b1f1ccba2bc1c12e94a2622840cae148eb8/templates/chartmuseum/chartmuseum-cm.yaml#L102

2. when you set the endpoint, the endpoint format must like this.
```
 [bucket].[region].aliyuncs.com or [bucket].[region]-internal.aliyuncs.com
```

 but charmuseum endpoint format not include `bucket`
```
 [region].aliyuncs.com or [region]-internal.aliyuncs.com
```
