### PR TITLE
fix expose.loadBalancer.ports.httpsPort in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `expose.loadBalancer.name` | The name of service |`harbor`|
 | `expose.loadBalancer.IP` | The IP of the loadBalancer.  It works only when loadBalancer support assigning IP |`""`|
 | `expose.loadBalancer.ports.httpPort` | The service port Harbor listens on when serving with HTTP |`80`|
-| `expose.loadBalancer.ports.httpsPort` | The service port Harbor listens on when serving with HTTP |`30002`|
+| `expose.loadBalancer.ports.httpsPort` | The service port Harbor listens on when serving with HTTPS |`30002`|
 | `expose.loadBalancer.ports.notaryPort` | The service port Notary listens on. Only needed when `notary.enabled` is set to `true`|
 | `expose.loadBalancer.annotations` | The annotations attached to the loadBalancer service | {} |
 | `expose.loadBalancer.sourceRanges` | List of IP address ranges to assign to loadBalancerSourceRanges | [] |


### PR DESCRIPTION
I hope this is correct. It sounded a little bit weird for me, if the resource is called `httpsPort` but the description says `HTTP` port.