### PR TITLE
Added customizable serviceAccountName for all components

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -32,6 +32,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.chartmuseum.serviceAccountName }}
+      serviceAccountName: {{ .Values.chartmuseum.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -25,6 +25,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.clair.serviceAccountName }}
+      serviceAccountName: {{ .Values.clair.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.core.serviceAccountName }}
+      serviceAccountName: {{ .Values.core.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.database.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.database.internal.serviceAccountName }}
+      serviceAccountName: {{ .Values.database.internal.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -32,6 +32,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.jobservice.serviceAccountName }}
+      serviceAccountName: {{ .Values.jobservice.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{ toYaml .Values.nginx.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.nginx.serviceAccountName }}
+      serviceAccountName: {{ .Values.nginx.serviceAccountName }}
+{{- end }}
       securityContext:
         fsGroup: 10000
       {{- with .Values.imagePullSecrets }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.notary.server.serviceAccountName }}
+      serviceAccountName: {{ .Values.notary.server.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -22,6 +22,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.notary.signer.serviceAccountName }}
+      serviceAccountName: {{ .Values.notary.signer.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- if .Values.portal.serviceAccountName }}
+      serviceAccountName: {{ .Values.portal.serviceAccountName }}
+{{- end -}}
       containers:
       - name: portal
         image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 999
+{{- if .Values.redis.internal.serviceAccountName }}
+      serviceAccountName: {{ .Values.redis.internal.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -32,6 +32,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.registry.serviceAccountName }}
+      serviceAccountName: {{ .Values.registry.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -20,6 +20,9 @@ spec:
 {{ include "harbor.labels" . | indent 8 }}
         component: trivy
     spec:
+{{- if .Values.trivy.serviceAccountName }}
+      serviceAccountName: {{ .Values.trivy.serviceAccountName }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 10000

--- a/values.yaml
+++ b/values.yaml
@@ -283,6 +283,8 @@ nginx:
   image:
     repository: goharbor/nginx-photon
     tag: dev
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   # resources:
   #  requests:
@@ -298,6 +300,8 @@ portal:
   image:
     repository: goharbor/harbor-portal
     tag: dev
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
 # resources:
 #  requests:
@@ -313,6 +317,8 @@ core:
   image:
     repository: goharbor/harbor-core
     tag: dev
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   ## Liveness probe values
   livenessProbe:
@@ -345,6 +351,8 @@ jobservice:
     repository: goharbor/harbor-jobservice
     tag: dev
   replicas: 1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
   jobLogger: file
@@ -363,11 +371,12 @@ jobservice:
   secret: ""
 
 registry:
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   registry:
     image:
       repository: goharbor/registry-photon
       tag: dev
-
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -381,6 +390,8 @@ registry:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   nodeSelector: {}
   tolerations: []
@@ -416,6 +427,8 @@ registry:
 
 chartmuseum:
   enabled: true
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   # Harbor defaults ChartMuseum to returning relative urls, if you want using absolute url you should enable it by change the following value to 'true'
   absoluteUrl: false
   image:
@@ -434,6 +447,8 @@ chartmuseum:
 
 clair:
   enabled: true
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   clair:
     image:
       repository: goharbor/clair-photon
@@ -468,6 +483,8 @@ trivy:
     repository: goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
     tag: dev
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   # replicas the number of Pod replicas
   replicas: 1
   # debugMode is the flag to enable Trivy debug mode with more verbose scanning log
@@ -505,6 +522,8 @@ trivy:
 notary:
   enabled: true
   server:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/notary-server-photon
       tag: dev
@@ -514,6 +533,8 @@ notary:
     #    memory: 256Mi
     #    cpu: 100m
   signer:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/notary-signer-photon
       tag: dev
@@ -540,6 +561,8 @@ database:
   # and fill the connection informations in "external" section
   type: internal
   internal:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/harbor-db
       tag: dev
@@ -588,6 +611,8 @@ redis:
   # and fill the connection informations in "external" section
   type: internal
   internal:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/redis-photon
       tag: dev


### PR DESCRIPTION
To be able to assign custom PodSecurityPolicies or OpenShift's SCCs to all harbor's components I added a parameter to each component.
Default behavior is retrocompatible, so default serviceaccount is used if a specific one is not specified.

Thought about setting a general serviceaccount for all the deployments, but in my case it was better to have them split.
Fixes https://github.com/goharbor/harbor-helm/issues/560