### PR TITLE
feat(ca-bundle): add custom ca bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `persistence.imageChartStorage.type`                                        | The type of storage for images and charts: `filesystem`, `azure`, `gcs`, `s3`, `swift` or `oss`. The type must be `filesystem` if you want to use persistent volumes for registry and chartmuseum. Refer to the [guide](https://github.com/docker/distribution/blob/master/docs/configuration.md#storage) for more information about the detail | `filesystem`                    |
 | **General**                                                                 |
 | `externalURL`                                                               | The external URL for Harbor core service                                                                                                                                                                                                                                                                                                        | `https://core.harbor.domain`    |
+| `caBundleSecretName` | The custom ca bundle secret name, the secret must contain key named "ca.crt" which will be injected into the trust store for chartmuseum, clair, core, jobservice, registry, trivy components. | |
 | `uaaSecretName` | If using external UAA auth which has a self signed cert, you can provide a pre-created secret containing it under the key `ca.crt`. | |
 | `imagePullPolicy` | The image pull policy |  |
 | `imagePullSecrets` | The imagePullSecrets names for all deployments |  |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -325,6 +325,18 @@ host:port,pool_size,password
   {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) (include "harbor.trivy" .) .Values.proxy.noProxy -}}
 {{- end -}}
 
+{{- define "harbor.caBundleVolume" -}}
+- name: ca-bundle-certs
+  secret:
+    secretName: {{ .Values.caBundleSecretName }}
+{{- end -}}
+
+{{- define "harbor.caBundleVolumeMount" -}}
+- name: ca-bundle-certs
+  mountPath: /harbor_cust_cert/custom-ca.crt
+  subPath: ca.crt
+{{- end -}}
+
 {{/* scheme for all components except notary because it only support http mode */}}
 {{- define "harbor.component.scheme" -}}
   {{- if .Values.internalTLS.enabled -}}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -119,6 +119,9 @@ spec:
           mountPath: /harbor_cust_cert/custom-ca-bundle.crt
           subPath: ca.crt
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: chartmuseum-data
       {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "filesystem") }}
@@ -144,6 +147,9 @@ spec:
       - name: storage-service-ca
         secret:
           secretName: {{ .Values.persistence.imageChartStorage.caBundleSecretName }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
       {{- with .Values.chartmuseum.nodeSelector }}
       nodeSelector:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -70,7 +70,7 @@ spec:
         - name: config
           mountPath: /etc/clair/config.yaml
           subPath: config.yaml
-      {{- if .Values.internalTLS.enabled }}
+        {{- if .Values.internalTLS.enabled }}
         - name: clair-internal-certs
           mountPath: /harbor_cust_cert/harbor_internal_ca.crt
           subPath: ca.crt
@@ -80,6 +80,9 @@ spec:
         - name: clair-internal-certs
           mountPath: /etc/harbor/ssl/clair_adapter.key
           subPath: tls.key
+        {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       - name: adapter
         image: {{ .Values.clair.adapter.image.repository }}:{{ .Values.clair.adapter.image.tag }}
@@ -130,8 +133,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ template "harbor.clairAdapter.containerPort" . }}
-        {{- if .Values.internalTLS.enabled }}
+        {{- if or .Values.internalTLS.enabled .Values.caBundleSecretName }}
         volumeMounts:
+        {{- if .Values.internalTLS.enabled }}
         - name: clair-internal-certs
           mountPath: /harbor_cust_cert/harbor_internal_ca.crt
           subPath: ca.crt
@@ -142,6 +146,10 @@ spec:
           mountPath: /etc/harbor/ssl/clair_adapter.key
           subPath: tls.key
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -150,6 +158,9 @@ spec:
       - name: clair-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.clair.secretName" . }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.clair.nodeSelector }}
       nodeSelector:

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -113,6 +113,9 @@ spec:
         {{- end }}
         - name: psc
           mountPath: /etc/core/token
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if .Values.core.resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -163,6 +166,9 @@ spec:
       {{- end }}
       - name: psc
         emptyDir: {}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -104,6 +104,9 @@ spec:
           mountPath: /etc/harbor/ssl/job_service.key
           subPath: tls.key
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: jobservice-config
         configMap:
@@ -119,6 +122,9 @@ spec:
       - name: jobservice-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.jobservice.secretName" . }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -130,6 +130,9 @@ spec:
           subPath: pk.pem
         {{- end }}
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       - name: registryctl
         image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -209,6 +212,9 @@ spec:
           mountPath: /etc/registry/gcs-key.json
           subPath: gcs-key.json
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: registry-htpasswd
         secret:
@@ -260,6 +266,9 @@ spec:
             - key: CLOUDFRONT_KEY_DATA
               path: pk.pem
       {{- end }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -98,11 +98,10 @@ spec:
             - name: api-server
               containerPort: {{ template "harbor.trivy.containerPort" . }}
           volumeMounts:
-            - name: data
-              mountPath: /home/scanner/.cache
-              readOnly: false
+          - name: data
+            mountPath: /home/scanner/.cache
+            readOnly: false
           {{- if .Values.internalTLS.enabled }}
-          volumeMounts:
           - name: trivy-internal-certs
             mountPath: /harbor_cust_cert/harbor_internal_ca.crt
             subPath: ca.crt
@@ -112,6 +111,9 @@ spec:
           - name: trivy-internal-certs
             mountPath: /etc/harbor/ssl/trivy.key
             subPath: tls.key
+          {{- end }}
+          {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 10 }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -133,13 +135,15 @@ spec:
             failureThreshold: 3
           resources:
 {{ toYaml .Values.trivy.resources | indent 12 }}
-      {{- if or (or .Values.internalTLS.enabled (not .Values.persistence.enabled)) (and .Values.persistence.enabled $trivy.existingClaim) }}
+      {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}
       volumes:
-      {{- end }}
       {{- if .Values.internalTLS.enabled }}
       - name: trivy-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.trivy.secretName" . }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
       {{- if not .Values.persistence.enabled }}
       - name: "data"
@@ -148,7 +152,8 @@ spec:
       - name: "data"
         persistentVolumeClaim:
           claimName: {{ $trivy.existingClaim }}
-      {{- end -}}
+      {{- end }}
+      {{- end }}
 {{- if and .Values.persistence.enabled (not $trivy.existingClaim) }}
   volumeClaimTemplates:
   - metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -341,6 +341,10 @@ proxy:
     - clair
     - trivy
 
+# The custom ca bundle secret, the secret must contain key named "ca.crt"
+# which will be injected into the trust store for chartmuseum, clair, core, jobservice, registry, trivy components
+# caBundleSecretName: ""
+
 ## UAA Authentication Options
 # If you're using UAA for authentication behind a self-signed
 # certificate you will need to provide the CA Cert.


### PR DESCRIPTION
Add custom ca bundle support for chartmuseum, clair, core, jobservice,
registry and trivy components.

Closes #529

Signed-off-by: He Weiwei <hweiwei@vmware.com>