### PR TITLE
[Cherry-pick]Use the value of XSRF key in value.yaml if user set it

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -51,7 +51,6 @@ data:
   PORTAL_URL: "{{ template "harbor.portalURL" . }}"
   REGISTRY_CONTROLLER_URL: "{{ template "harbor.registryControllerURL" . }}"
   REGISTRY_CREDENTIAL_USERNAME: "{{ .Values.registry.credentials.username }}"
-  CSRF_KEY: "{{ randAlphaNum 32 }}"
   {{- if .Values.uaaSecretName }}
   UAA_CA_ROOT: "/etc/core/auth-ca/auth-ca.crt"
   {{- end }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -18,3 +18,4 @@ data:
 {{- if .Values.clair.enabled }}
   CLAIR_DB_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
 {{- end }}
+  CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}


### PR DESCRIPTION
Fixes #597, use the value of XSRF key in value.yaml if user set it

Signed-off-by: Wenkai Yin <yinw@vmware.com>