### PR TITLE
[Cherry pick]Add Trivy to no_proxy configuration

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -322,7 +322,7 @@ host:port,pool_size,password
 {{- end -}}
 
 {{- define "harbor.noProxy" -}}
-  {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) .Values.proxy.noProxy -}}
+  {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) (include "harbor.trivy" .) .Values.proxy.noProxy -}}
 {{- end -}}
 
 {{/* scheme for all components except notary because it only support http mode */}}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -43,6 +43,14 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           env:
+          {{- if has "trivy" .Values.proxy.components }}
+            - name: HTTP_PROXY
+              value: "{{ .Values.proxy.httpProxy }}"
+            - name: HTTPS_PROXY
+              value: "{{ .Values.proxy.httpsProxy }}"
+            - name: NO_PROXY
+              value: "{{ template "harbor.noProxy" . }}"
+          {{- end }}
             - name: "SCANNER_LOG_LEVEL"
               value: {{ .Values.logLevel | quote }}
             - name: "SCANNER_TRIVY_CACHE_DIR"

--- a/values.yaml
+++ b/values.yaml
@@ -339,6 +339,7 @@ proxy:
     - core
     - jobservice
     - clair
+    - trivy
 
 ## UAA Authentication Options
 # If you're using UAA for authentication behind a self-signed


### PR DESCRIPTION
Without that option Core will not able to reach Trivy's
HTTP endpoint if any proxy is configured

Fixes #595

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>