### PR TITLE
fix: helm lint reported issue

### DIFF
--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
 {{- if .Values.portal.serviceAccountName }}
       serviceAccountName: {{ .Values.portal.serviceAccountName }}
-{{- end -}}
+{{- end }}
       containers:
       - name: portal
         image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}


### PR DESCRIPTION
The Chart can not be rendered due to whitespace removal

Introduced in #573, see the lint error report:
https://github.com/goharbor/harbor-helm/pull/573#issuecomment-639295313

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>