### PR TITLE
Chartmuseum: Set AWS_SDK_LOAD_CONFIG to make S3 work in more cases

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -95,6 +95,9 @@ spec:
               secretKeyRef:
                 name: {{ template "harbor.core" . }}
                 key: secret
+          - # Needed to make AWS' client connect correctly (see https://github.com/helm/chartmuseum/issues/280)
+            name: AWS_SDK_LOAD_CONFIG
+            value: "1"
         ports:
         - containerPort: {{ template "harbor.chartmuseum.containerPort" . }}
         volumeMounts:


### PR DESCRIPTION
Needed for Chartmuseum to work with some S3 setups. I have only tested this on a self-hosted version of S3, so I can't speak for the "official" S3 servers.

See https://github.com/helm/chartmuseum/issues/280 for more details.