### PR TITLE
Update Ingress apiVersion for support Kubernetes v1.16

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -25,7 +25,7 @@
 {{- end }}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress" . }}"
@@ -88,7 +88,7 @@ spec:
 
 {{- if .Values.notary.enabled  }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress-notary" . }}"

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -25,11 +25,11 @@
 {{- end }}
 
 ---
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
-{{- else -}}
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
-{{- end -}}
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress" . }}"
@@ -92,11 +92,11 @@ spec:
 
 {{- if .Values.notary.enabled  }}
 ---
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
-{{- else -}}
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
-{{- end -}}
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress-notary" . }}"

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -25,7 +25,11 @@
 {{- end }}
 
 ---
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end -}}
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress" . }}"
@@ -88,7 +92,11 @@ spec:
 
 {{- if .Values.notary.enabled  }}
 ---
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end -}}
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress-notary" . }}"

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -25,7 +25,7 @@
 {{- end }}
 
 ---
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -92,7 +92,7 @@ spec:
 
 {{- if .Values.notary.enabled  }}
 ---
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
This PR is for update Ingress apiVersion from `extensions/v1beta1` to `networking.k8s.io/v1beta1` for supporting Kubernetes v1.16.

Closes #628 

Signed-off-by: Rodolfo Martínez <rodomar@outlook.com>