### PR TITLE
Fix conflict between ingress secretNames

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -105,7 +105,7 @@ spec:
     {{- else if $tls.secretName }}
   - secretName: {{ $tls.secretName }}
     {{- else }}
-  - secretName: "{{ template "harbor.ingress" . }}"
+  - secretName: "{{ template "harbor.ingress-notary" . }}"
     {{- end }}
     {{- if $ingress.hosts.notary }}
     hosts:


### PR DESCRIPTION
I found using the default configuration with cert-manager would cause the same secret to be used for both ingresses:

```yaml
        expose:
          ingress:
            annotations:
              cert-manager.io/cluster-issuer: letsencrypt-production-cloudflare
```

This creates two ingresses, but with one certificate.

```
kubectl -n harbor get certificate
NAME                    READY   SECRET                  AGE
harbor-harbor-ingress   True    harbor-harbor-ingress   16m
```

The certificate uses the 'notary' hostname, breaking the non-notary ingress.