### PR TITLE
Postgres: chmod 0700 database-files before startup

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -37,7 +37,7 @@ spec:
         image: {{ .Values.database.internal.initContainerImage.repository }}:{{ .Values.database.internal.initContainerImage.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]
+        args: ["-c", "chown -R 999:999 /var/lib/postgresql/data; chmod -R 0700 /var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
Fixes the following error on database restart (possibly related to
particulars of PV/PVC setup):

    FATAL:  data directory "/var/lib/postgresql/data" has group or world access
    DETAIL:  Permissions should be u=rwx (0700).