### PR TITLE
Remove unneeded args from registryctl container

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -157,7 +157,6 @@ spec:
         resources:
 {{ toYaml .Values.registry.controller.resources | indent 10 }}
 {{- end }}
-        args: ["serve", "/etc/registry/config.yml"]
         envFrom:
         - secretRef:
             name: "{{ template "harbor.registry" . }}"


### PR DESCRIPTION
The registryctl container arguments are not used/needed.

Signed-off-by: Stefan Nica <snica@suse.com>