### PR TITLE
Add environment variable "SCANNER_REDIS_URL" for trivy adapter

### DIFF
--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -91,6 +91,11 @@ spec:
             - name: SCANNER_API_SERVER_TLS_CERTIFICATE
               value: /etc/harbor/ssl/trivy.crt
             {{- end }}
+            - name: "SCANNER_REDIS_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "harbor.trivy" . }}
+                  key: redisURL
             - name: "SCANNER_STORE_REDIS_URL"
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Add environment variable "SCANNER_REDIS_URL" for trivy adapter

Signed-off-by: Wenkai Yin <yinw@vmware.com>