### PR TITLE
.helmignore was helm-ignoring .travis.yaml, not .travis.yml

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -2,5 +2,5 @@ docs/*
 .git/*
 .gitignore
 CONTRIBUTING.md
-.travis.yaml
+.travis.yml
 test/*


### PR DESCRIPTION
updates .helmignore to ignore .travis.yml rather than .yaml, because currently the .travis.yml isn't being helm-ignore'd. not a huge deal.

I read through the contributing guidelines and I think this is okay. if not, if someone else wants to fix the helmignore real quick on their own, that's fine we can just close this out. or we can just close it out altogether.

thanks 👍 