### PR TITLE
fix endpoint syntax conflict

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -115,7 +115,7 @@ data:
         region: {{ $storage.oss.region }}
         bucket: {{ $storage.oss.bucket }}
         {{- if $storage.oss.endpoint }}
-        endpoint: {{ $storage.oss.endpoint }}
+        endpoint: {{ $storage.oss.bucket }}.{{ $storage.oss.endpoint }}
         {{- end }}
         {{- if $storage.oss.internal }}
         internal: {{ $storage.oss.internal }}


### PR DESCRIPTION
docker registry and chartmuseum config endpoint syntax conflict

https://chartmuseum.com/docs/#using-with-alibaba-cloud-oss-storage
--storage-alibaba-endpoint="oss-cn-beijing.aliyuncs.com"

https://docs.docker.com/registry/storage-drivers/oss/?spm=5176.100239.blogcont7585.14.OScRv1
An endpoint which defaults to [bucket].[region].aliyuncs.com or [bucket].[region]-internal.aliyuncs.com (when internal=true). You can change the default endpoint by changing this value.