### PR TITLE
fix Chart.yaml icon

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - registry
 - harbor
 home: https://goharbor.io
-icon: https://raw.githubusercontent.com/goharbor/harbor/master/docs/img/harbor_logo.png
+icon: https://raw.githubusercontent.com/goharbor/website/master/static/img/logos/harbor-icon-color.png
 sources:
 - https://github.com/goharbor/harbor
 - https://github.com/goharbor/harbor-helm


### PR DESCRIPTION
Since the harbor documentation was moved from the official git repository, the icon specified in the `Chart.yaml` https://raw.githubusercontent.com/goharbor/harbor/master/docs/img/harbor_logo.png does not exist anymore. This pull request fixes this by using the harbor logo of a previous commit (which will also be a stable URL in the future).