### PR TITLE
Provide the registry as a top level var

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `uaaSecretName` | If using external UAA auth which has a self signed cert, you can provide a pre-created secret containing it under the key `ca.crt`. | |
 | `imagePullPolicy` | The image pull policy |  |
 | `imagePullSecrets` | The imagePullSecrets names for all deployments |  |
+| `imageRegistry` | The image registry to use | docker.io |
 | `updateStrategy.type` | The update strategy for deployments with persistent volumes(jobservice, registry and chartmuseum): `RollingUpdate` or `Recreate`. Set it as `Recreate` when `RWM` for volumes isn't supported  | `RollingUpdate` |
 | `logLevel` | The log level: `debug`, `info`, `warning`, `error` or `fatal` | `info` |
 | `harborAdminPassword`                                                       | The initial password of Harbor admin. Change it from portal after launching Harbor                                                                                                                                                                                                                                                              | `Harbor12345`                   |

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
       - name: chartmuseum
-        image: {{ .Values.chartmuseum.image.repository }}:{{ .Values.chartmuseum.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.chartmuseum.image.repository }}:{{ .Values.chartmuseum.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: clair
-        image: {{ .Values.clair.clair.image.repository }}:{{ .Values.clair.clair.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.clair.clair.image.repository }}:{{ .Values.clair.clair.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:
@@ -88,7 +88,7 @@ spec:
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       - name: adapter
-        image: {{ .Values.clair.adapter.image.repository }}:{{ .Values.clair.adapter.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.clair.adapter.image.repository }}:{{ .Values.clair.adapter.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
       - name: core
-        image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -36,7 +36,7 @@ spec:
       - name: "change-permission-of-directory"
         securityContext:
           runAsUser: 0
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
         args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data"]
@@ -45,7 +45,7 @@ spec:
           mountPath: /var/lib/postgresql/data
           subPath: {{ $database.subPath }}
       - name: "remove-lost-found"
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["rm", "-Rf", "/var/lib/postgresql/data/lost+found"]
         volumeMounts:
@@ -54,7 +54,7 @@ spec:
           subPath: {{ $database.subPath }}
       containers:
       - name: database
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           exec:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
       - name: jobservice
-        image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: nginx
-        image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+        image: "{{ .Values.imageRegistry }}/{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         {{- $_ := set . "scheme" "HTTP" -}}
         {{- $_ := set . "port" "8080" -}}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
       - name: notary-server
-        image: {{ .Values.notary.server.image.repository }}:{{ .Values.notary.server.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.notary.server.image.repository }}:{{ .Values.notary.server.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- if .Values.notary.server.resources }}
         resources:

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: notary-signer
-        image: {{ .Values.notary.signer.image.repository }}:{{ .Values.notary.signer.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.notary.signer.image.repository }}:{{ .Values.notary.signer.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- if .Values.notary.signer.resources }}
         resources:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- end }}
       containers:
       - name: portal
-        image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- if .Values.portal.resources }}
         resources:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
       - name: redis
-        image: {{ .Values.redis.internal.image.repository }}:{{ .Values.redis.internal.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.redis.internal.image.repository }}:{{ .Values.redis.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           tcpSocket:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
       - name: registry
-        image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:
@@ -137,7 +137,7 @@ spec:
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       - name: registryctl
-        image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
+        image: {{ .Values.imageRegistry }}/{{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -44,7 +44,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: trivy
-          image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
+          image: {{ .Values.imageRegistry }}/{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           securityContext:
             privileged: false

--- a/values.yaml
+++ b/values.yaml
@@ -312,6 +312,9 @@ persistence:
 
 imagePullPolicy: IfNotPresent
 
+# Set the registry to use for all images
+imageRegistry: docker.io
+
 # Use this set to assign a list of default pullSecrets
 imagePullSecrets:
 #  - name: docker-registry-secret


### PR DESCRIPTION
When dealing with different registry, or registry proxy, it's a better user experience to expose the registry used, rather than force them to set all of the image variables. 

Prior to this change, if you wanted to move all images to pull from the gcr.io registry you would have to overwrite all image values as follow:

```
nginx.image.repository: gcr.io/goharbor/nginx-photon
portal.image.repository: gcr.io/goharbor/harbor-portal
core.image.repository: gcr.io/goharbor/harbor-core
jobservice.image.repository: gcr.io/goharbor/harbor-jobservice
registry.registry.image.repository: gcr.io/goharbor/registry-photon
registry.controller.image.repository: gcr.io/goharbor/harbor-registryctl
database.internal.image.repository: gcr.io/goharbor/harbor-db
redis.internal.image.repository: gcr.io/goharbor/redis-photon
chartmuseum.image.repository: gcr.io/goharbor/chartmuseum-photon
clair.clair.image.repository: gcr.io/goharbor/clair-photon
clair.adapter.image.repository: gcr.io/goharbor/clair-adapter-photon
trivy.image.repository: gcr.io/goharbor/trivy-adapter-photon
notary.server.image.repository: gcr.io/goharbor/notary-server-photon
notary.signer.image.repository: gcr.io/goharbor/notary-signer-photon
```

With this fix, it is now a 1 line change:
```
imageRegistry: gcr.io
```

Tested via helm template output:
```
$ helm template . | grep "image: "
 image: docker.io/goharbor/chartmuseum-photon:dev
 image: docker.io/goharbor/clair-photon:dev
 image: docker.io/goharbor/clair-adapter-photon:dev
 image: docker.io/goharbor/harbor-core:dev
 image: docker.io/goharbor/harbor-jobservice:dev
 image: docker.io/goharbor/notary-server-photon:dev
 image: docker.io/goharbor/notary-signer-photon:dev
 image: docker.io/goharbor/harbor-portal:dev
 image: docker.io/goharbor/registry-photon:dev
 image: docker.io/goharbor/harbor-registryctl:dev
 image: docker.io/goharbor/harbor-db:dev
 image: docker.io/goharbor/harbor-db:dev
 image: docker.io/goharbor/harbor-db:dev
 image: docker.io/goharbor/redis-photon:dev
 image: docker.io/goharbor/trivy-adapter-photon:dev
```
Set registry to `gcr.io`
```
$ helm template . --set imageRegistry=gcr.io | grep "image: "
 image: gcr.io/goharbor/chartmuseum-photon:dev
 image: gcr.io/goharbor/clair-photon:dev
 image: gcr.io/goharbor/clair-adapter-photon:dev
 image: gcr.io/goharbor/harbor-core:dev
 image: gcr.io/goharbor/harbor-jobservice:dev
 image: gcr.io/goharbor/notary-server-photon:dev
 image: gcr.io/goharbor/notary-signer-photon:dev
 image: gcr.io/goharbor/harbor-portal:dev
 image: gcr.io/goharbor/registry-photon:dev
 image: gcr.io/goharbor/harbor-registryctl:dev
 image: gcr.io/goharbor/harbor-db:dev
 image: gcr.io/goharbor/harbor-db:dev
 image: gcr.io/goharbor/harbor-db:dev
 image: gcr.io/goharbor/redis-photon:dev
 image: gcr.io/goharbor/trivy-adapter-photon:dev
```