### PR TITLE
Convert the log level for registry

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -8,7 +8,13 @@ data:
   config.yml: |+
     version: 0.1
     log:
+      {{- if eq .Values.logLevel "warning" }}
+      level: warn
+      {{- else if eq .Values.logLevel "fatal" }}
+      level: error
+      {{- else }}
       level: {{ .Values.logLevel }}
+      {{- end }}
       fields:
         service: registry
     storage:


### PR DESCRIPTION
Convert the log level for registry as registry doesn't support warning and fatal

Signed-off-by: Wenkai Yin <yinw@vmware.com>