### PR TITLE
Fix extensions/v1beta1 deprecations

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -28,7 +28,7 @@
 {{- end }}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress" . }}"
@@ -91,7 +91,7 @@ spec:
 
 {{- if .Values.notary.enabled  }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress-notary" . }}"


### PR DESCRIPTION
The kubernetes extensions/v1beta1 Ingress API has been deprecated
in v1.16 in favor of networking.k8s.io/v1beta1 [1]. extensions/v1beta1
will be completely removed in kubernetes 1.18 [2].

https://github.com/kubernetes/enhancements/issues/758
https://github.com/kubernetes/kubernetes/issues/43214