### PR TITLE
Set "expose.tls.auto.commonName" when serving with node port

### DIFF
--- a/test/integration/node_port_test.go
+++ b/test/integration/node_port_test.go
@@ -20,7 +20,7 @@ func TestNodePortTestSuite(t *testing.T) {
 	suite.Run(t, &NodePortTestSuite{
 		BaseTestSuite: NewBaseTestSuite(map[string]string{
 			"expose.type":                          "nodePort",
-			"expose.tls.commonName":                "127.0.0.1",
+			"expose.tls.auto.commonName":           "127.0.0.1",
 			"expose.nodePort.ports.https.nodePort": "30003",
 			"externalURL":                          "https://127.0.0.1:30003",
 		}),


### PR DESCRIPTION
The common name is changed to "expose.tls.auto.commonName", this PR update it

Signed-off-by: Wenkai Yin <yinw@vmware.com>