### PR TITLE
Fix notary_server & notary_signer auth via certs

### DIFF
--- a/conf/notary-server.json
+++ b/conf/notary-server.json
@@ -7,7 +7,7 @@
     "hostname": "{{ template "harbor.notary-signer" . }}",
     "port": "7899",
     "tls_ca_file": "/etc/ssl/notary/ca.crt",
-    "key_algorithm": "ecdsa"
+    "key_algorithm": "rsa"
   },
   "logging": {
     "level": "{{ .Values.logLevel }}"


### PR DESCRIPTION
Config notary-server.json contain option "key_algorithm" with a wrong value (in case of auto generate certs) which is the cause of the next error in notary-server logs:

```
{"level":"error","msg":"Trust not fully operational: rpc error: code = 13 desc = connection error: desc = \"transport: x509: certificate signed by unknown authority (possibly because of \\\"crypto/rsa: verification error\\\" while trying to verify candidate authority certificate \\\"harbor-notary-ca\\\")\"","time":"2020-09-07T14:16:11Z"}
```