### PR TITLE
[harbor] Bump minor version to v2.1.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor
-version: 1.4.0-dev
-appVersion: dev
+version: 1.5.0
+appVersion: 2.1.0
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:
 - docker

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ expose:
     # images. Refer to https://github.com/goharbor/harbor/issues/5291
     # for the detail.
     enabled: true
-    # The source of the tls certificate. Set it as "auto", "secret" 
+    # The source of the tls certificate. Set it as "auto", "secret"
     # or "none" and fill the information in the corresponding section
     # 1) auto: generate the tls certificate automatically
     # 2) secret: read the tls certificate from the specified secret.
@@ -374,7 +374,7 @@ proxy:
 nginx:
   image:
     repository: goharbor/nginx-photon
-    tag: dev
+    tag: v2.1.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -391,7 +391,7 @@ nginx:
 portal:
   image:
     repository: goharbor/harbor-portal
-    tag: dev
+    tag: v2.1.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -408,7 +408,7 @@ portal:
 core:
   image:
     repository: goharbor/harbor-core
-    tag: dev
+    tag: v2.1.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -441,7 +441,7 @@ core:
 jobservice:
   image:
     repository: goharbor/harbor-jobservice
-    tag: dev
+    tag: v2.1.0
   replicas: 1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
@@ -468,7 +468,7 @@ registry:
   registry:
     image:
       repository: goharbor/registry-photon
-      tag: dev
+      tag: v2.1.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -476,7 +476,7 @@ registry:
   controller:
     image:
       repository: goharbor/harbor-registryctl
-      tag: dev
+      tag: v2.1.0
 
     # resources:
     #  requests:
@@ -523,7 +523,7 @@ chartmuseum:
   absoluteUrl: false
   image:
     repository: goharbor/chartmuseum-photon
-    tag: dev
+    tag: v2.1.0
   replicas: 1
   # resources:
   #  requests:
@@ -542,7 +542,7 @@ clair:
   clair:
     image:
       repository: goharbor/clair-photon
-      tag: dev
+      tag: v2.1.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -550,7 +550,7 @@ clair:
   adapter:
     image:
       repository: goharbor/clair-adapter-photon
-      tag: dev
+      tag: v2.1.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -572,7 +572,7 @@ trivy:
     # repository the repository for Trivy adapter image
     repository: goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
-    tag: dev
+    tag: v2.1.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # replicas the number of Pod replicas
@@ -629,7 +629,7 @@ notary:
     serviceAccountName: ""
     image:
       repository: goharbor/notary-server-photon
-      tag: dev
+      tag: v2.1.0
     replicas: 1
     # resources:
     #  requests:
@@ -640,7 +640,7 @@ notary:
     serviceAccountName: ""
     image:
       repository: goharbor/notary-signer-photon
-      tag: dev
+      tag: v2.1.0
     replicas: 1
     # resources:
     #  requests:
@@ -668,7 +668,7 @@ database:
     serviceAccountName: ""
     image:
       repository: goharbor/harbor-db
-      tag: dev
+      tag: v2.1.0
     # The initial superuser password for internal database
     password: "changeit"
     # resources:
@@ -714,7 +714,7 @@ redis:
     serviceAccountName: ""
     image:
       repository: goharbor/redis-photon
-      tag: dev
+      tag: v2.1.0
     # resources:
     #  requests:
     #    memory: 256Mi


### PR DESCRIPTION
In this PR, we bump Harbor docker images to the latest stable release which points to `v2.1.0`.

PS: This should point to new release branch at `1.5.0` (?)
