### PR TITLE
Fixes proxy-body-size for ingress deployment

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -44,7 +44,7 @@ expose:
       ingress.kubernetes.io/ssl-redirect: "true"
       ingress.kubernetes.io/proxy-body-size: "1m"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
   clusterIP:
     # The name of ClusterIP service
     name: harbor

--- a/values.yaml
+++ b/values.yaml
@@ -42,7 +42,9 @@ expose:
     controller: default
     annotations:
       ingress.kubernetes.io/ssl-redirect: "true"
+      ingress.kubernetes.io/proxy-body-size: "1m"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "1m"
   clusterIP:
     # The name of ClusterIP service
     name: harbor

--- a/values.yaml
+++ b/values.yaml
@@ -42,9 +42,7 @@ expose:
     controller: default
     annotations:
       ingress.kubernetes.io/ssl-redirect: "true"
-      ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
   clusterIP:
     # The name of ClusterIP service
     name: harbor


### PR DESCRIPTION
In the default values the ingress proxy-body-size was set to 0. It makes an ingress deployment broken. The default value as define in the NGINX documentation is 1m. 0 makes no sense here.

Fixes issue #731 