### PR TITLE
 fix use ingress it will return 401 unauthorized when push image to the server

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -179,6 +179,9 @@ data:
         key: /etc/harbor/ssl/registry/tls.key
         minimumtls: tls1.2
       {{- end }}
+      {{- if eq .Values.expose.type "ingress" }}
+      host: {{ .Values.expose.ingress.hosts  }}
+      {{- end }}
       # set via environment variable
       # secret: placeholder
       debug:


### PR DESCRIPTION
fix issue: #622 

when use ingress, it will return 401 when no hosts configuration on the config.yaml