### PR TITLE
Generate more values, protect them for the upgrade

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,3 +1,15 @@
 Please wait for several minutes for Harbor deployment to complete.
 Then you should be able to visit the Harbor portal at {{ .Values.externalURL }}
 For more details, please visit https://github.com/goharbor/harbor
+
+{{ "" }}
+{{- if .Release.IsInstall }}
+  {{- if eq "Harbor12345" .Values.harborAdminPassword }}
+The default password was set for Administrator user. Change it as soon as you log in to the Portal service.
+  {{- else if eq "" .Values.harborAdminPassword }}
+The password for Portal Administrator user was generated randomly. Fetch it by running this command:
+{{ "" }}
+kubectl get secret {{ template "harbor.core" . }} -n {{.Release.Namespace}} -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode
+{{ "" }}
+ {{- end }}
+{{- end }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  secretKey: {{ .Values.secretKey | b64enc | quote }}
+  secretKey: {{ .Values.core.secretKey | default (randAlphaNum 16) | b64enc | quote }}
   secret: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
 {{- if not .Values.core.secretName }}
   tls.crt: {{ .Files.Get "cert/tls.crt" | b64enc }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -1,18 +1,51 @@
+{{- $secret := include "harbor.core" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "harbor.core" . }}
+  name: {{ $secret }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+{{- if .Release.IsUpgrade }}
+  {{- $prevSecret := (lookup "v1" "Secret" .Release.Namespace $secret) }}
+  {{- if .Values.secretKey }}
+  secretKey: {{ .Values.secretKey | b64enc | quote }}
+  {{- else if $prevSecret }}
+  secretKey: {{ $prevSecret.data.secretKey }}
+  {{- else }}
+  secretKey: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secret }}
+  secret: {{ .Values.secret | b64enc | quote }}
+  {{- else if $prevSecret }}
+  secret: {{ $prevSecret.data.secret }}
+  {{- else }}
+  secret: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.harborAdminPassword }}
+  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
+  {{- else if $prevSecret }}
+  HARBOR_ADMIN_PASSWORD: {{ $prevSecret.data.HARBOR_ADMIN_PASSWORD }}
+  {{- else }}
+  HARBOR_ADMIN_PASSWORD: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.core.xsrfKey }}
+  CSRF_KEY: {{ .Values.core.xsrfKey | b64enc | quote }}
+  {{- else if $prevSecret }}
+  CSRF_KEY: {{ $prevSecret.data.CSRF_KEY }}
+  {{- else }}
+  CSRF_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+{{- else }}
   secretKey: {{ .Values.core.secretKey | default (randAlphaNum 16) | b64enc | quote }}
   secret: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
+  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | default (randAlphaNum 16) | b64enc | quote }}
+  CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
+{{- end }}
 {{- if not .Values.core.secretName }}
   tls.crt: {{ .Files.Get "cert/tls.crt" | b64enc }}
   tls.key: {{ .Files.Get "cert/tls.key" | b64enc }}
 {{- end }}
-  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | default (randAlphaNum 16) | b64enc | quote }}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
-  CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -12,7 +12,7 @@ data:
   tls.crt: {{ .Files.Get "cert/tls.crt" | b64enc }}
   tls.key: {{ .Files.Get "cert/tls.key" | b64enc }}
 {{- end }}
-  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
+  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | default (randAlphaNum 16) | b64enc | quote }}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
   CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -1,10 +1,22 @@
+{{- $secret := include "harbor.jobservice" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "harbor.jobservice" . }}"
+  name: {{ $secret }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if .Release.IsUpgrade }}
+    {{- $prevSecret := (lookup "v1" "Secret" .Release.Namespace $secret) }}
+    {{- if .Values.jobservice.secret }}
+  JOBSERVICE_SECRET: {{ .Values.jobservice.secret | b64enc | quote }}
+    {{- else if $prevSecret }}
+  JOBSERVICE_SECRET: {{ $prevSecret.data.JOBSERVICE_SECRET }}
+    {{- else }}
+  JOBSERVICE_SECRET: {{ randAlphaNum 16 | b64enc | quote }}
+    {{- end }}
+  {{- else }}
   JOBSERVICE_SECRET: {{ .Values.jobservice.secret | default (randAlphaNum 16) | b64enc | quote }}
+  {{- end }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -1,13 +1,25 @@
+{{- $secret := include "harbor.registry" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "harbor.registry" . }}"
+  name: {{ $secret }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  REGISTRY_HTPASSWD: {{ .Values.registry.credentials.htpasswd | b64enc | quote }}
+  {{- if .Release.IsUpgrade }}
+    {{- $prevSecret := (lookup "v1" "Secret" .Release.Namespace $secret) }}
+    {{- if .Values.registry.secret }}
+  REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | b64enc | quote }}
+    {{- else if $prevSecret }}
+  REGISTRY_HTTP_SECRET: {{ $prevSecret.data.REGISTRY_HTTP_SECRET }}
+    {{- else }}
+  REGISTRY_HTTP_SECRET: {{ randAlphaNum 16 | b64enc | quote }}
+    {{- end }}
+  {{- else }}
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (randAlphaNum 16) | b64enc | quote }}
+  {{- end }}
+  REGISTRY_HTPASSWD: {{ .Values.registry.credentials.htpasswd | b64enc | quote }}
   REGISTRY_REDIS_PASSWORD: {{ (include "harbor.redis.password" .) | b64enc | quote }}
   {{- $storage := .Values.persistence.imageChartStorage }}
   {{- $type := $storage.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -346,7 +346,8 @@ harborAdminPassword: "Harbor12345"
 caSecretName: ""
 
 # The secret key used for encryption. Must be a string of 16 chars.
-secretKey: "not-a-secure-key"
+# If a value is not specified, Helm will generate one.
+secretKey: ""
 
 # The proxy settings for updating clair vulnerabilities from the Internet and replicating
 # artifacts from/to the registries that cannot be reached directly


### PR DESCRIPTION
Allow generation of more random values where it makes sense. 
On upgrade, fetch the existing ones and do not randomize again.

Signed-off-by: Jiří Suchomel <jiri.suchomel@suse.com>
