### PR TITLE
Bump helm 2 version for linter and allow helm 2 linter failures

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        helm_version: [3.2.3, 2.16.8]
+        helm_version: [3.2.3, 2.16.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +26,7 @@ jobs:
           helm version -c
 
       - name: Run lint
+        continue-on-error: ${{ startsWith(matrix.helm_version, '2.') }}
         working-directory: ./harbor
         run:
           helm lint .


### PR DESCRIPTION
Helm 2 is deprecated and will no longer be maintained after Nov 2020
[1]. The helm 2 linter already prevents some advanced features from
being used in the Harbor helm chart [2] and this will not be fixed.

This commit updates the helm 2 used by the linter to the latest
available version and makes the helm 2 linter check continue on failure.

[1] https://helm.sh/blog/helm-v2-deprecation-timeline/
[2] helm/helm#7955

Signed-off-by: Stefan Nica <snica@suse.com>