### PR TITLE
Fixes harbor/harbor#8224

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -39,7 +39,7 @@ spec:
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data"]
+        args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data && chmod 0700 /var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
Changes the mode of the postgres database directory to remove group and others permissions.  This is needed on some container storage interfaces such as rook-ceph with CephFS and RADOS block device as they create directories with 0777 permissions by default, which PostgreSQL doesn't like.