### PR TITLE
enable startupProbe only on k8s > 1.18

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -42,6 +42,7 @@ spec:
       - name: core
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
         startupProbe:
           httpGet:
             path: /api/v2.0/ping
@@ -50,6 +51,7 @@ spec:
           failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
           periodSeconds: 10
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v2.0/ping


### PR DESCRIPTION
Startupprobe is activated by default only with k8s version > 1.18.0, see: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

on k8s 1.15, i got this error: `Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "startupProbe" in io.k8s.api.core.v1.C`