### PR TITLE
Update to correct helm chart label format

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -18,16 +18,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{/* Helm required labels */}}
 {{- define "harbor.labels" -}}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
-chart: {{ .Chart.Name }}
-app: "{{ template "harbor.name" . }}"
+app.kubernetes.io/name: {{ template "harbor.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/* matchLabels */}}
 {{- define "harbor.matchLabels" -}}
-release: {{ .Release.Name }}
-app: "{{ template "harbor.name" . }}"
+app.kubernetes.io/name: "{{ template "harbor.name" . }}"
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "harbor.autoGenCert" -}}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ template "harbor.chartmuseum" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: chartmuseum
+    app.kubernetes.io/component: chartmuseum
 spec:
   replicas: {{ .Values.chartmuseum.replicas }}
   strategy:
@@ -16,12 +16,12 @@ spec:
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: chartmuseum
+      app.kubernetes.io/component: chartmuseum
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: chartmuseum
+        app.kubernetes.io/component: chartmuseum
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/chartmuseum/chartmuseum-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/chartmuseum/chartmuseum-secret.yaml") . | sha256sum }}

--- a/templates/chartmuseum/chartmuseum-pvc.yaml
+++ b/templates/chartmuseum/chartmuseum-pvc.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: chartmuseum
+    app.kubernetes.io/component: chartmuseum
 spec:
   accessModes: 
     - {{ $chartmuseum.accessMode }}

--- a/templates/chartmuseum/chartmuseum-svc.yaml
+++ b/templates/chartmuseum/chartmuseum-svc.yaml
@@ -11,5 +11,5 @@ spec:
       targetPort: {{ template "harbor.chartmuseum.containerPort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: chartmuseum
+    app.kubernetes.io/component: chartmuseum
 {{- end }}

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -5,18 +5,18 @@ metadata:
   name: {{ template "harbor.clair" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: clair
+    app.kubernetes.io/component: clair
 spec:
   replicas: {{ .Values.clair.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: clair
+      app.kubernetes.io/component: clair
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: clair
+        app.kubernetes.io/component: clair
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/clair/clair-secret.yaml") . | sha256sum }}
 {{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "auto") }}

--- a/templates/clair/clair-svc.yaml
+++ b/templates/clair/clair-svc.yaml
@@ -11,5 +11,5 @@ spec:
       port: {{ include "harbor.clairAdapter.servicePort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: clair
+    app.kubernetes.io/component: clair
 {{ end }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -4,18 +4,18 @@ metadata:
   name: {{ template "harbor.core" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: core
+    app.kubernetes.io/component: core
 spec:
   replicas: {{ .Values.core.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: core
+      app.kubernetes.io/component: core
   template:
     metadata:
       labels:
 {{ include "harbor.matchLabels" . | indent 8 }}
-        component: core
+        app.kubernetes.io/component: core
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/core/core-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/core/core-secret.yaml") . | sha256sum }}

--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -13,4 +13,4 @@ spec:
       targetPort: {{ template "harbor.core.containerPort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: core
+    app.kubernetes.io/component: core

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -6,19 +6,19 @@ metadata:
   name: "{{ template "harbor.database" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: database
+    app.kubernetes.io/component: database
 spec:
   replicas: 1
   serviceName: "{{ template "harbor.database" . }}"
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: database
+      app.kubernetes.io/component: database
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: database
+        app.kubernetes.io/component: database
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/database/database-secret.yaml") . | sha256sum }}
 {{- if .Values.database.podAnnotations }}

--- a/templates/database/database-svc.yaml
+++ b/templates/database/database-svc.yaml
@@ -10,5 +10,5 @@ spec:
     - port: 5432
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: database
+    app.kubernetes.io/component: database
 {{- end -}}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "harbor.jobservice" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: jobservice
+    app.kubernetes.io/component: jobservice
 spec:
   replicas: {{ .Values.jobservice.replicas }}
   strategy:
@@ -15,12 +15,12 @@ spec:
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: jobservice
+      app.kubernetes.io/component: jobservice
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: jobservice
+        app.kubernetes.io/component: jobservice
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/jobservice/jobservice-cm.yaml") . | sha256sum }}
         checksum/configmap-env: {{ include (print $.Template.BasePath "/jobservice/jobservice-cm-env.yaml") . | sha256sum }}

--- a/templates/jobservice/jobservice-pvc.yaml
+++ b/templates/jobservice/jobservice-pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: jobservice
+    app.kubernetes.io/component: jobservice
 spec:
   accessModes: 
     - {{ $jobservice.accessMode }}

--- a/templates/jobservice/jobservice-svc.yaml
+++ b/templates/jobservice/jobservice-svc.yaml
@@ -10,4 +10,4 @@ spec:
       targetPort: {{ template "harbor.jobservice.containerPort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: jobservice
+    app.kubernetes.io/component: jobservice

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -5,18 +5,18 @@ metadata:
   name: {{ template "harbor.nginx" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: nginx
+    app.kubernetes.io/component: nginx
 spec:
   replicas: {{ .Values.nginx.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: nginx
+      app.kubernetes.io/component: nginx
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: nginx
+        app.kubernetes.io/component: nginx
       annotations:
       {{- if not .Values.expose.tls.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/nginx/configmap-http.yaml") . | sha256sum }}

--- a/templates/nginx/service.yaml
+++ b/templates/nginx/service.yaml
@@ -88,5 +88,5 @@ spec:
 {{- end }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: nginx
+    app.kubernetes.io/component: nginx
 {{- end }}

--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "harbor.notary-server" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: notary
+    app.kubernetes.io/component: notary
 type: Opaque
 data:
   {{- if not .Values.notary.secretName }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -5,18 +5,18 @@ metadata:
   name: {{ template "harbor.notary-server" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: notary-server
+    app.kubernetes.io/component: notary-server
 spec:
   replicas: {{ .Values.notary.server.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: notary-server
+      app.kubernetes.io/component: notary-server
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: notary-server
+        app.kubernetes.io/component: notary-server
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/notary/notary-secret.yaml") . | sha256sum }}
         checksum/secret-core: {{ include (print $.Template.BasePath "/core/core-secret.yaml") . | sha256sum }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -5,18 +5,18 @@ metadata:
   name: {{ template "harbor.notary-signer" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: notary-signer
+    app.kubernetes.io/component: notary-signer
 spec:
   replicas: {{ .Values.notary.signer.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: notary-signer
+      app.kubernetes.io/component: notary-signer
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: notary-signer
+        app.kubernetes.io/component: notary-signer
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/notary/notary-secret.yaml") . | sha256sum }}
     spec:

--- a/templates/notary/notary-svc.yaml
+++ b/templates/notary/notary-svc.yaml
@@ -13,7 +13,7 @@ spec:
   - port: 4443
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: notary-server
+    app.kubernetes.io/component: notary-server
 
 ---
 apiVersion: v1
@@ -27,5 +27,5 @@ spec:
   - port: 7899
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: notary-signer
+    app.kubernetes.io/component: notary-signer
 {{ end }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -4,18 +4,18 @@ metadata:
   name: "{{ template "harbor.portal" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: portal
+    app.kubernetes.io/component: portal
 spec:
   replicas: {{ .Values.portal.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: portal
+      app.kubernetes.io/component: portal
   template:
     metadata:
       labels:
 {{ include "harbor.matchLabels" . | indent 8 }}
-        component: portal
+        app.kubernetes.io/component: portal
       annotations:
 {{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "auto") }}
         checksum/tls: {{ include (print $.Template.BasePath "/internal/auto-tls.yaml") . | sha256sum }}

--- a/templates/portal/service.yaml
+++ b/templates/portal/service.yaml
@@ -10,4 +10,4 @@ spec:
       targetPort: {{ template "harbor.portal.containerPort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: portal
+    app.kubernetes.io/component: portal

--- a/templates/redis/service.yaml
+++ b/templates/redis/service.yaml
@@ -10,5 +10,5 @@ spec:
     - port: 6379
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: redis
+    app.kubernetes.io/component: redis
 {{- end -}}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -6,19 +6,19 @@ metadata:
   name: {{ template "harbor.redis" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: redis
+    app.kubernetes.io/component: redis
 spec:
   replicas: 1
   serviceName: {{ template "harbor.redis" . }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: redis
+      app.kubernetes.io/component: redis
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: redis
+        app.kubernetes.io/component: redis
 {{- if .Values.redis.podAnnotations }}
       annotations:
 {{ toYaml .Values.redis.podAnnotations | indent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "harbor.registry" . }}"
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: registry
+    app.kubernetes.io/component: registry
 spec:
   replicas: {{ .Values.registry.replicas }}
   strategy:
@@ -15,12 +15,12 @@ spec:
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: registry
+      app.kubernetes.io/component: registry
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: registry
+        app.kubernetes.io/component: registry
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-cm.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/registry/registry-secret.yaml") . | sha256sum }}

--- a/templates/registry/registry-pvc.yaml
+++ b/templates/registry/registry-pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: registry
+    app.kubernetes.io/component: registry
 spec:
   accessModes: 
     - {{ $registry.accessMode }}

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -12,4 +12,4 @@ spec:
       port: {{ template "harbor.registryctl.servicePort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: registry
+    app.kubernetes.io/component: registry

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -6,19 +6,19 @@ metadata:
   name: {{ template "harbor.trivy" . }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
-    component: trivy
+    app.kubernetes.io/component: trivy
 spec:
   replicas: {{ .Values.trivy.replicas }}
   serviceName: {{  template "harbor.trivy" . }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}
-      component: trivy
+      app.kubernetes.io/component: trivy
   template:
     metadata:
       labels:
 {{ include "harbor.labels" . | indent 8 }}
-        component: trivy
+        app.kubernetes.io/component: trivy
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/trivy/trivy-secret.yaml") . | sha256sum }}
 {{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "auto") }}

--- a/templates/trivy/trivy-svc.yaml
+++ b/templates/trivy/trivy-svc.yaml
@@ -12,5 +12,5 @@ spec:
       port: {{ template "harbor.trivy.servicePort" . }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
-    component: trivy
+    app.kubernetes.io/component: trivy
 {{ end }}


### PR DESCRIPTION
The previous helm chart label format was significantly out of date and was making it difficult to find the appropriate resources to manage for the harbor application. This pull request updates to the new recommended label format as described here: https://helm.sh/docs/chart_best_practices/labels/#standard-labels.

To perform this update, I needed to edit two of the named templates (`harbor.labels` and `harbor.matchLabels`) from `templates/_helpers.tpl`. This took care of updating the following tags:
- `heritage: {{ .Release.Service }}` -> `app.kubernetes.io/managed-by: {{ .Release.Service }}`
- `release: {{ .Release.Name }}` -> `app.kubernetes.io/instance: {{ .Release.Name }}`
- `chart: {{ .Chart.Name }}` -> `helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}`
- `app: {{ template "harbor.name" . }}` -> `app.kubernetes.io/name: {{ template "harbor.name" .}}`

In addition, since the `component` tag varies throughout the chart, it can't be generically templated and needed to be updated in each template file. In each place that `component: <component name>` was defined, I replaced it with `app.kubernetes.io/component: <component name>`.