### PR TITLE
Set database directory permissions in init container

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -39,7 +39,7 @@ spec:
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data"]
+        args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data && chmod 0700 /var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
PostgreSQL requires the /var/lib/postgresql/data directory to have 0700 permissions.
When the pod is restarted the file system permissions are reset and the database always crashes.
The permissions for the directory need to be set in the init container every time the pod is started.

Fix #444
See also: [goharbor/harbor#8224](https://github.com/goharbor/harbor/issues/8224)