### PR TITLE
Make startupProbe optional

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -43,6 +43,7 @@ spec:
       - name: core
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
           httpGet:
             path: /api/v2.0/ping
@@ -51,6 +52,7 @@ spec:
           failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
           periodSeconds: 10
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v2.0/ping

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ expose:
     # images. Refer to https://github.com/goharbor/harbor/issues/5291
     # for the detail.
     enabled: true
-    # The source of the tls certificate. Set it as "auto", "secret" 
+    # The source of the tls certificate. Set it as "auto", "secret"
     # or "none" and fill the information in the corresponding section
     # 1) auto: generate the tls certificate automatically
     # 2) secret: read the tls certificate from the specified secret.
@@ -415,6 +415,7 @@ core:
   replicas: 1
   ## Startup probe values
   startupProbe:
+    enabled: true
     initialDelaySeconds: 10
   # resources:
   #  requests:


### PR DESCRIPTION
Alternative to: https://github.com/goharbor/harbor-helm/pull/773

Instead try to detect a correct k8s version, just decide the user if they want to use startupProbes.

startupProbes are implement as Feature Gate but disabled by default since 1.16.

Since 1.18, `startupProbes` are enabled by default.

Using a strict `if version >= 1.18` check my help in general but users they enabled startupProbes in 1.16 could not benefit from.