### PR TITLE
Fix ingress paths for ingress-nginx 0.41.0

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -19,11 +19,11 @@
   {{- $_ := set . "notary_path" "/.*" -}}
 {{- else }}
   {{- $_ := set . "portal_path" "/" -}}
-  {{- $_ := set . "api_path" "/api/" -}}
-  {{- $_ := set . "service_path" "/service/" -}}
-  {{- $_ := set . "v2_path" "/v2/" -}}
-  {{- $_ := set . "chartrepo_path" "/chartrepo/" -}}
-  {{- $_ := set . "controller_path" "/c/" -}}
+  {{- $_ := set . "api_path" "/api" -}}
+  {{- $_ := set . "service_path" "/service" -}}
+  {{- $_ := set . "v2_path" "/v2" -}}
+  {{- $_ := set . "chartrepo_path" "/chartrepo" -}}
+  {{- $_ := set . "controller_path" "/c" -}}
   {{- $_ := set . "notary_path" "/" -}}
 {{- end }}
 


### PR DESCRIPTION
The ingress-nginx 0.41.0 version changes the default `ImplementationSpecific`
`pathType` to adhere to the kubernetes ingress `pathType` specification [1].
The specification doesn't cover matching paths ending in a trailing `/`
for the `Prefix` `pathType`, which means trailing `/` must be removed.

[1] https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

Fixes #783

Signed-off-by: Stefan Nica <snica@suse.com>