### PR TITLE
Configure notary deployments at server/signer level

### DIFF
--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -20,8 +20,8 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/notary/notary-secret.yaml") . | sha256sum }}
         checksum/secret-core: {{ include (print $.Template.BasePath "/core/core-secret.yaml") . | sha256sum }}
-{{- if .Values.notary.podAnnotations }}
-{{ toYaml .Values.notary.podAnnotations | indent 8 }}
+{{- if .Values.notary.server.podAnnotations }}
+{{ toYaml .Values.notary.server.podAnnotations | indent 8 }}
 {{- end }}
     spec:
       securityContext:
@@ -75,15 +75,15 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
-    {{- with .Values.notary.nodeSelector }}
+    {{- with .Values.notary.server.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.notary.affinity }}
+    {{- with .Values.notary.server.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.notary.tolerations }}
+    {{- with .Values.notary.server.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -19,6 +19,9 @@ spec:
         component: notary-signer
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/notary/notary-secret.yaml") . | sha256sum }}
+{{- if .Values.notary.signer.podAnnotations }}
+{{ toYaml .Values.notary.signer.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       securityContext:
         runAsUser: 10000
@@ -66,15 +69,15 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
-    {{- with .Values.notary.nodeSelector }}
+    {{- with .Values.notary.signer.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.notary.affinity }}
+    {{- with .Values.notary.signer.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.notary.tolerations }}
+    {{- with .Values.notary.signer.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -636,6 +636,11 @@ notary:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    ## Additional deployment annotations
+    podAnnotations: {}
   signer:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
@@ -647,11 +652,11 @@ notary:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  ## Additional deployment annotations
-  podAnnotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    ## Additional deployment annotations
+    podAnnotations: {}
   # Fill the name of a kubernetes secret if you want to use your own
   # TLS certificate authority, certificate and private key for notary
   # communications.


### PR DESCRIPTION
This change moves the `podAnnotations`, `nodeSelector`, `affinity` and
`tolerations` from the notary level to the server and signer level.

This allows configuring those options specifically for the server or
signer deployments instead of using the same configuration for both.

Fixes: #789

Signed-off-by: Flávio Ramalho <framalho@suse.com>