### PR TITLE
fix(chartmuseum) compatible s3 cache fail

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -109,4 +109,5 @@ data:
   {{- end }}
   ALIBABA_CLOUD_ACCESS_KEY_ID: {{ $storage.oss.accesskeyid }}
 {{- end }}
+  STORAGE_TIMESTAMP_TOLERANCE: 1s
 {{- end }}


### PR DESCRIPTION
some compatible s3 like DELL EMC s3 has some strange behavior that make the chart index cache not working
reference issue https://github.com/goharbor/harbor/issues/13592 and pr https://github.com/goharbor/harbor/pull/13600 