### PR TITLE
[cherry-pick] fix(chartmuseum) compatible s3 cache fail for 1.5.2

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -109,4 +109,5 @@ data:
   {{- end }}
   ALIBABA_CLOUD_ACCESS_KEY_ID: {{ $storage.oss.accesskeyid }}
 {{- end }}
+  STORAGE_TIMESTAMP_TOLERANCE: 1s
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ziming Zhang <zziming@vmware.com>