### PR TITLE
update comments around ssl-redirect annotation for Envoy

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,8 @@ expose:
     # set to `ncp` if using the NCP (NSX-T Container Plugin) ingress controller
     controller: default
     annotations:
+      # note different ingress controllers may require a different ssl-redirect annotation
+      # for Envoy, use ingress.kubernetes.io/force-ssl-redirect: "true" and remove the nginx lines below
       ingress.kubernetes.io/ssl-redirect: "true"
       ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
The helm chart here assumes annotations for nginx ingress, this PR clarifies changes may need to be made and gives an example of what to do for Envoy