### PR TITLE
Define registry host

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -178,6 +178,9 @@ data:
         idletimeout: 60s
     http:
       addr: :{{ template "harbor.registry.containerPort" . }}
+      {{- if .Values.registry.host }}
+      host: {{.Values.registry.host | quote }}
+      {{- end }}
       relativeurls: {{ .Values.registry.relativeurls }}
       {{- if .Values.internalTLS.enabled }}
       tls:
@@ -205,7 +208,7 @@ data:
     compatibility:
       schema1:
         enabled: true
-    
+
     {{- if .Values.registry.middleware.enabled }}
     {{- $middleware := .Values.registry.middleware }}
     {{- $middlewareType := $middleware.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -540,6 +540,10 @@ registry:
     # e.g. "htpasswd -nbBC10 $username $password"
     htpasswd: "harbor_registry_user:$2y$10$9L4Tc0DJbFFMB6RdSCunrOpTHdwhid4ktBJmLD00bYgqkkGOvll3m"
 
+  # Overrides registry host. Omit if empty. Required if X-Forwarded-For or Forwarded header incorrectly implemented on infrastructure side.
+  # protocol and port is required. Example: http://core.harbor.domain:8080
+  host: ""
+
   middleware:
     enabled: false
     type: cloudFront


### PR DESCRIPTION
Allows to overrides registry host. 

Required if X-Forwarded-For or Forwarded header incorrectly implemented on infrastructure side.