### PR TITLE
[Cherry-pick]Fix ingress paths for ingress-nginx 0.41.0

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -42,6 +42,7 @@ spec:
       - name: core
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
           httpGet:
             path: /api/v2.0/ping
@@ -50,6 +51,7 @@ spec:
           failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
           periodSeconds: 10
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v2.0/ping

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -19,11 +19,11 @@
   {{- $_ := set . "notary_path" "/.*" -}}
 {{- else }}
   {{- $_ := set . "portal_path" "/" -}}
-  {{- $_ := set . "api_path" "/api/" -}}
-  {{- $_ := set . "service_path" "/service/" -}}
-  {{- $_ := set . "v2_path" "/v2/" -}}
-  {{- $_ := set . "chartrepo_path" "/chartrepo/" -}}
-  {{- $_ := set . "controller_path" "/c/" -}}
+  {{- $_ := set . "api_path" "/api" -}}
+  {{- $_ := set . "service_path" "/service" -}}
+  {{- $_ := set . "v2_path" "/v2" -}}
+  {{- $_ := set . "chartrepo_path" "/chartrepo" -}}
+  {{- $_ := set . "controller_path" "/c" -}}
   {{- $_ := set . "notary_path" "/" -}}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ expose:
     # images. Refer to https://github.com/goharbor/harbor/issues/5291
     # for the detail.
     enabled: true
-    # The source of the tls certificate. Set it as "auto", "secret" 
+    # The source of the tls certificate. Set it as "auto", "secret"
     # or "none" and fill the information in the corresponding section
     # 1) auto: generate the tls certificate automatically
     # 2) secret: read the tls certificate from the specified secret.
@@ -415,6 +415,7 @@ core:
   replicas: 1
   ## Startup probe values
   startupProbe:
+    enabled: true
     initialDelaySeconds: 10
   # resources:
   #  requests:


### PR DESCRIPTION
The ingress-nginx 0.41.0 version changes the default `ImplementationSpecific`
`pathType` to adhere to the kubernetes ingress `pathType` specification [1].
The specification doesn't cover matching paths ending in a trailing `/`
for the `Prefix` `pathType`, which means trailing `/` must be removed.

[1] https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

Fixes #783

Signed-off-by: Stefan Nica <snica@suse.com>