### PR TITLE
chore(vers): updates apiVersion for Ingress

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -30,8 +30,10 @@
 ---
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
-{{- else }}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -93,8 +95,10 @@ spec:
 ---
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
-{{- else }}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:


### PR DESCRIPTION
ApiVersion for Ingress resource is updated from /v1beta1 to /v1 in 1.19.
This patch set updates the version to suppress warning [0].

[0] W1214 16:05:27.903491 1293447 warnings.go:67] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress

Signed-off-by: Tin Lam <tin@irrational.io>