### PR TITLE
Remove the reference to "registry-root-certificate"

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -98,9 +98,6 @@ spec:
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}
           subPath: {{ .Values.persistence.persistentVolumeClaim.registry.subPath }}
-        - name: registry-root-certificate
-          mountPath: /etc/registry/root.crt
-          subPath: tls.crt
         - name: registry-htpasswd
           mountPath: /etc/registry/passwd
           subPath: passwd
@@ -212,13 +209,6 @@ spec:
           items:
             - key: REGISTRY_HTPASSWD
               path: passwd
-      - name: registry-root-certificate
-        secret:
-          {{- if .Values.core.secretName }}
-          secretName: {{ .Values.core.secretName }}
-          {{- else }}
-          secretName: {{ template "harbor.core" . }}
-          {{- end }}
       - name: registry-config
         configMap:
           name: "{{ template "harbor.registry" . }}"


### PR DESCRIPTION
Remove the reference as this is a public key and registry will no longer
need it for token verification.
fixes #646

Signed-off-by: Daniel Jiang <jiangd@vmware.com>