### PR TITLE
Add fullnameOverride and remove duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The following table lists the configurable parameters of the Harbor chart and th
 
 | Parameter                                                                   | Description                                                                                                                                                                                                                                                                                                                                     | Default                         |
 | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Chart** |
+| `nameOverride` | | `harbor` |
+| `fullnameOverride` |
 | **Expose** |
 | `expose.type` | The way how to expose the service: `ingress`, `clusterIP`, `nodePort` or `loadBalancer`, other values will be ignored and the creation of service will be skipped. | `ingress` |
 | `expose.tls.enabled` | Enable the tls or not. Delete the `ssl-redirect` annotations in `expose.ingress.annotations` when TLS is disabled and `expose.type` is `ingress`. Note: if the `expose.type` is `ingress` and the tls is disabled, the port must be included in the command when pull/push images. Refer to https://github.com/goharbor/harbor/issues/5291 for the detail. | `true` |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -10,11 +10,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "harbor.fullname" -}}
-{{- $name := default "harbor" .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/* Helm required labels */}}
 {{- define "harbor.labels" -}}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -13,8 +12,8 @@ type IngressTestSuite struct {
 }
 
 func (i *IngressTestSuite) TestIngress() {
-	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-harbor-ingress", i.ReleaseName))
-	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-harbor-ingress-notary", i.ReleaseName))
+	k8s.GetIngress(i.T(), i.Options.KubectlOptions, "harbor-ingress")
+	k8s.GetIngress(i.T(), i.Options.KubectlOptions, "harbor-ingress-notary")
 }
 
 func TestIngressTestSuite(t *testing.T) {

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 expose:
   # Set the way how to expose the service. Set the type as "ingress",
   # "clusterIP", "nodePort" or "loadBalancer" and fill the information


### PR DESCRIPTION
I'm running only one instance of harbor (release name is `harbor`, but it ends up as `harbor-harbor` everywhere :(

The latest (3.4.2) helm uses the `fullnameOverride` (in addition to `nameOverride`) to handle this case:

See https://github.com/helm/helm/blob/v3.4.2/pkg/chartutil/create.go#L409-L425
