### PR TITLE
Fix for networking.k8s.io/v1 Ingress

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,22 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [v1.18.2, v1.17.5, v1.16.9]
+        k8s_version: [v1.20.0, v1.19.4, v1.18.8, v1.17.11, v1.16.15]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@0.0.1
+        uses: docker-practice/actions-setup-docker@v1
         with:
-          docker_version: 18.09
+          docker_version: "20.10"
           docker_channel: stable
           docker_daemon_json: '{"insecure-registries":["0.0.0.0/0"]}'
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.1.0
         with:
-          version: v0.8.1
+          version: v0.9.0
           node_image: kindest/node:${{ matrix.k8s_version }}
           cluster_name: kind-cluster-${{ matrix.k8s_version }}
           config: test/integration/kind-cluster.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go 1.13
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: "1.13"
 
       - name: Cache go mod
         uses: actions/cache@v2

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -63,6 +63,7 @@ spec:
   rules:
   - http:
       paths:
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
       - path: {{ .portal_path }}
         backend:
           serviceName: {{ template "harbor.portal" . }}
@@ -87,6 +88,50 @@ spec:
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: {{ template "harbor.core.servicePort" . }}
+{{- else }}
+      - path: {{ .portal_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.portal" . }}
+            port:
+              number: {{ template "harbor.portal.servicePort" . }}
+      - path: {{ .api_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .service_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .v2_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .chartrepo_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .controller_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+{{- end }}
     {{- if $ingress.hosts.core }}
     host: {{ $ingress.hosts.core }}
     {{- end }}
@@ -127,8 +172,15 @@ spec:
       paths:
       - path: {{ .notary_path }}
         backend:
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
           serviceName: {{ template "harbor.notary-server" . }}
           servicePort: 4443
+{{- else }}
+          service:
+            name: {{ template "harbor.notary-server" . }}
+            port:
+              number: 4443
+{{- end -}}
     {{- if $ingress.hosts.notary }}
     host: {{ $ingress.hosts.notary }}
     {{- end }}

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -171,11 +171,13 @@ spec:
   - http:
       paths:
       - path: {{ .notary_path }}
-        backend:
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+        backend:
           serviceName: {{ template "harbor.notary-server" . }}
           servicePort: 4443
 {{- else }}
+        pathType: Prefix
+        backend:
           service:
             name: {{ template "harbor.notary-server" . }}
             port:


### PR DESCRIPTION
v1 Ingress requires changes in `rules` - so helm against k8s (e.g. 1.19.3 in my case) is failing.

This PR fixes it without updating integration test github action to test against k8s 1.19 as well.

Follow-up of #814.