### PR TITLE
Enable proxy cache for more registries

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -52,7 +52,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"


### PR DESCRIPTION
Enable proxy cache for more registries
Signed-off-by: Wenkai Yin <yinw@vmware.com>