### PR TITLE
fix: render password in config.yml only it's not empty

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -166,7 +166,9 @@ data:
       sentinelMasterSet: {{ template "harbor.redis.masterSet" . }}
       {{- end }}
       db: {{ template "harbor.redis.dbForRegistry" . }}
+      {{- if not (eq (include "harbor.redis.password" .) "") }}
       password: {{ template "harbor.redis.password" . }}
+      {{- end }}
       readtimeout: 10s
       writetimeout: 10s
       dialtimeout: 10s


### PR DESCRIPTION
Render redis password in the config.yml of registry only when it's not
empty.

Signed-off-by: He Weiwei <hweiwei@vmware.com>