### PR TITLE
Add lowercase proxy environment variables

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -81,6 +81,12 @@ spec:
             value: "{{ .Values.proxy.httpsProxy }}"
           - name: NO_PROXY
             value: "{{ template "harbor.noProxy" . }}"
+          - name: http_proxy
+            value: "{{ .Values.proxy.httpProxy }}"
+          - name: https_proxy
+            value: "{{ .Values.proxy.httpsProxy }}"
+          - name: no_proxy
+            value: "{{ template "harbor.noProxy" . }}"
           {{- end }}
           {{- if .Values.internalTLS.enabled }}
           - name: INTERNAL_TLS_ENABLED

--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -49,6 +49,9 @@ data:
   HTTP_PROXY: "{{ .Values.proxy.httpProxy }}"
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
+  http_proxy: "{{ .Values.proxy.httpProxy }}"
+  https_proxy: "{{ .Values.proxy.httpsProxy }}"
+  no_proxy: "{{ template "harbor.noProxy" . }}"
   {{- end }}
   PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay"
   {{- if .Values.metrics.enabled}}

--- a/templates/exporter/exporter-cm-env.yaml
+++ b/templates/exporter/exporter-cm-env.yaml
@@ -10,6 +10,9 @@ data:
   HTTP_PROXY: "{{ .Values.proxy.httpProxy }}"
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
+  http_proxy: "{{ .Values.proxy.httpProxy }}"
+  https_proxy: "{{ .Values.proxy.httpsProxy }}"
+  no_proxy: "{{ template "harbor.noProxy" . }}"
   {{- end }}
   HARBOR_EXPORTER_PORT: "{{ .Values.metrics.exporter.port }}"
   HARBOR_EXPORTER_METRICS_PATH: "{{ .Values.metrics.exporter.path }}"

--- a/templates/jobservice/jobservice-cm-env.yaml
+++ b/templates/jobservice/jobservice-cm-env.yaml
@@ -14,4 +14,7 @@ data:
   HTTP_PROXY: "{{ .Values.proxy.httpProxy }}"
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
+  http_proxy: "{{ .Values.proxy.httpProxy }}"
+  https_proxy: "{{ .Values.proxy.httpsProxy }}"
+  no_proxy: "{{ template "harbor.noProxy" . }}"
   {{- end }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -80,6 +80,12 @@ spec:
           value: "{{ .Values.proxy.httpsProxy }}"
         - name: NO_PROXY
           value: "{{ template "harbor.noProxy" . }}"
+        - name: http_proxy
+          value: "{{ .Values.proxy.httpProxy }}"
+        - name: https_proxy
+          value: "{{ .Values.proxy.httpsProxy }}"
+        - name: no_proxy
+          value: "{{ template "harbor.noProxy" . }}"
         {{- end }}
         {{- if .Values.internalTLS.enabled }}
         - name: INTERNAL_TLS_ENABLED

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -56,6 +56,12 @@ spec:
               value: "{{ .Values.proxy.httpsProxy }}"
             - name: NO_PROXY
               value: "{{ template "harbor.noProxy" . }}"
+            - name: http_proxy
+              value: "{{ .Values.proxy.httpProxy }}"
+            - name: https_proxy
+              value: "{{ .Values.proxy.httpsProxy }}"
+            - name: no_proxy
+              value: "{{ template "harbor.noProxy" . }}"
           {{- end }}
             - name: "SCANNER_LOG_LEVEL"
               value: {{ .Values.logLevel | quote }}


### PR DESCRIPTION
* Add lowercase proxy environment variables (`*_proxy`) to core, chartmuseum, exporter, jobservice, registry, and trivy.
* Relates to #864.