### PR TITLE
(fix): expose metrics ports

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -96,6 +96,10 @@ spec:
          {{- end }}
         ports:
         - containerPort: {{ template "harbor.core.containerPort" . }}
+        {{- if .Values.metrics.enabled}}
+        - name: metrics
+          containerPort: {{ .Values.metrics.core.port }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/core/app.conf

--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "harbor.core" . }}
   labels:
+    component: core
 {{ include "harbor.labels" . | indent 4 }}
 spec:
 {{- if  (eq .Values.expose.ingress.controller "gce") }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -60,6 +60,10 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ template "harbor.core.containerPort" . }}
+        {{- if .Values.metrics.enabled}}
+        - name: metrics
+          containerPort: {{ .Values.metrics.exporter.port }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}

--- a/templates/exporter/exporter-svc.yaml
+++ b/templates/exporter/exporter-svc.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: "{{ template "harbor.exporter" . }}"
   labels:
+    component: exporter
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -94,6 +94,10 @@ spec:
         ports:
         - containerPort: {{ template "harbor.registry.containerPort" . }}
         - containerPort: 5001
+        {{- if .Values.metrics.enabled}}
+        - name: metrics
+          containerPort: {{ .Values.metrics.registry.port }}
+        {{- end }}
         volumeMounts:
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: "{{ template "harbor.registry" . }}"
   labels:
+    component: registry
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:


### PR DESCRIPTION
- ServiceMonitor can not work without explicitly exposed ports on deployments. 
- Now its possible to use component label selector

```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: harbor
  labels:
    release: prometheus-stack
spec:
  selector:
    matchLabels:
      app: harbor
  endpoints:
  - targetPort: 8001
```