### PR TITLE
Update ingress rules

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -19,11 +19,11 @@
   {{- $_ := set . "notary_path" "/.*" -}}
 {{- else }}
   {{- $_ := set . "portal_path" "/" -}}
-  {{- $_ := set . "api_path" "/api" -}}
-  {{- $_ := set . "service_path" "/service" -}}
+  {{- $_ := set . "api_path" "/api/" -}}
+  {{- $_ := set . "service_path" "/service/" -}}
   {{- $_ := set . "v2_path" "/v2" -}}
-  {{- $_ := set . "chartrepo_path" "/chartrepo" -}}
-  {{- $_ := set . "controller_path" "/c" -}}
+  {{- $_ := set . "chartrepo_path" "/chartrepo/" -}}
+  {{- $_ := set . "controller_path" "/c/" -}}
   {{- $_ := set . "notary_path" "/" -}}
 {{- end }}
 


### PR DESCRIPTION
Portal introduces a new file called "common.js", it is matched by the ingress rule of core "/c" which is mistake. This commit adds the suffix "/" for each rules to avoid such cases

Signed-off-by: Wenkai Yin <yinw@vmware.com>