### PR TITLE
Rename service ports for compatibility with istio.

### DIFF
--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -9,11 +9,11 @@ spec:
   type: NodePort
 {{- end }}
   ports:
-    - name: web
+    - name: {{ ternary "https-web" "http-web" .Values.internalTLS.enabled }}
       port: {{ template "harbor.core.servicePort" . }}
       targetPort: {{ template "harbor.core.containerPort" . }}
 {{- if .Values.metrics.enabled}}
-    - name: metrics
+    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
       port: {{ .Values.metrics.core.port }}
 {{- end }}
   selector:

--- a/templates/exporter/exporter-svc.yaml
+++ b/templates/exporter/exporter-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: metrics
+    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
       port: {{ .Values.metrics.exporter.port }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -6,12 +6,13 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: registry
+    - name: {{ ternary "https-registry" "http-registry" .Values.internalTLS.enabled }}
       port: {{ template "harbor.registry.servicePort" . }}
-    - name: controller
+
+    - name: {{ ternary "https-controller" "http-controller" .Values.internalTLS.enabled }}
       port: {{ template "harbor.registryctl.servicePort" . }}
 {{- if .Values.metrics.enabled}}
-    - name: metrics
+    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
       port: {{ .Values.metrics.registry.port }}
 {{- end }}
   selector:

--- a/templates/trivy/trivy-svc.yaml
+++ b/templates/trivy/trivy-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: api-server
+    - name: {{ ternary "https-trivy" "http-trivy" .Values.internalTLS.enabled }}
       protocol: TCP
       port: {{ template "harbor.trivy.servicePort" . }}
   selector:


### PR DESCRIPTION
If sevice port names are used, Istio expects the following convention: <protocol>[-<suffix>]
If the port names does not follow the convention, then istio is not able to route traffic properly.

Fixes #77

Signed-off-by: Jehoszafat Zimnowoda <jehoszafat.zimnowoda@redkubes.com>