### PR TITLE
Add Subject Alternate Names for Ingress Certificates

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -53,6 +53,9 @@ spec:
     hosts:
     - {{ $ingress.hosts.core }}
     {{- end }}
+    {{- if $ingress.hosts.coreSANS }}
+    {{ toYaml $ingress.hosts.coreSANS }}
+    {{- end }}
   {{- end }}
   rules:
   - http:
@@ -84,7 +87,35 @@ spec:
     {{- if $ingress.hosts.core }}
     host: {{ $ingress.hosts.core }}
     {{- end }}
-
+    {{- range $hostnames := $ingress.hosts.coreSANS }}
+  - http:
+      paths:
+      - path: {{ print $.portal_path }}
+        backend:
+          serviceName: {{ template "harbor.portal" $ }}
+          servicePort: {{ template "harbor.portal.servicePort" $ }}
+      - path: {{ print $.api_path }}
+        backend:
+          serviceName: {{ template "harbor.core" $ }}
+          servicePort: {{ template "harbor.core.servicePort" $ }}
+      - path: {{ print $.service_path }}
+        backend:
+          serviceName: {{ template "harbor.core" $ }}
+          servicePort: {{ template "harbor.core.servicePort" $ }}
+      - path: {{ print $.v2_path }}
+        backend:
+          serviceName: {{ template "harbor.core" $ }}
+          servicePort: {{ template "harbor.core.servicePort" $ }}
+      - path: {{ print $.chartrepo_path }}
+        backend:
+          serviceName: {{ template "harbor.core" $ }}
+          servicePort: {{ template "harbor.core.servicePort" $ }}
+      - path: {{ print $.controller_path }}
+        backend:
+          serviceName: {{ template "harbor.core" $ }}
+          servicePort: {{ template "harbor.core.servicePort" $ }}
+    host: {{ $hostnames }}    
+    {{- end }}
 {{- if .Values.notary.enabled  }}
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
This will resolve https://github.com/goharbor/harbor-helm/issues/900.  I hacked around on this a bit and got it to work, but I'm sure there are other (better) ways to handle this.  Feel free to steer me in a different direction if there is a better one.

I left the existing $ingress.hosts.core value to maintain backwards compatibility.  Was tested with and without alternate host names defined.