### PR TITLE
Add annotations for artifacthub.io

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,4 +19,33 @@ maintainers:
   email: hweiwei@vmware.com
 - name: Qian Deng
   email: dengq@vmware.com
+annotations:
+  artifacthub.io/images: |
+    - name: nginx-photon
+      image: goharbor/nginx-photon:dev
+    - name: harbor-portal
+      image: goharbor/harbor-portal:dev
+    - name: harbor-core
+      image: goharbor/harbor-core:dev
+    - name: harbor-jobservice
+      image: goharbor/harbor-jobservice:dev
+    - name: registry-photon
+      image: goharbor/registry-photon:dev
+    - name: harbor-registryctl
+      image: goharbor/harbor-registryctl:dev
+    - name: chartmuseum-photon
+      image: goharbor/chartmuseum-photon:dev
+    - name: trivy-adapter-photon
+      image: goharbor/trivy-adapter-photon:dev
+    - name: notary-server-photon
+      image: goharbor/notary-server-photon:dev
+    - name: notary-signer-photon
+      image: goharbor/notary-signer-photon:dev
+    - name: harbor-db
+      image: goharbor/harbor-db:dev
+    - name: redis-photon
+      image: goharbor/redis-photon:dev
+    - name: harbor-exporter
+      image: goharbor/harbor-exporter:dev
+  artifacthub.io/license: Apache-2.0
 engine: gotpl


### PR DESCRIPTION
These annotations tell artifacthub:
1. The license for the chart
2. The images used by the chart. This enables AH to do things like
   vuln scan them.

Note, when a release is cut the :dev should be updated to the
proper tag just like the instances in values.yaml