### PR TITLE
Disable update strategy when there is no pvc in chartmuseum and registry

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -8,11 +8,13 @@ metadata:
     component: chartmuseum
 spec:
   replicas: {{ .Values.chartmuseum.replicas }}
+  {{- if (eq .Values.persistence.imageChartStorage.type "filesystem") }}
   strategy:
     type: {{ .Values.updateStrategy.type }}
     {{- if eq .Values.updateStrategy.type "Recreate" }}
     rollingUpdate: null
     {{- end }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -7,11 +7,13 @@ metadata:
     component: registry
 spec:
   replicas: {{ .Values.registry.replicas }}
+  {{- if (eq .Values.persistence.imageChartStorage.type "filesystem") }}
   strategy:
     type: {{ .Values.updateStrategy.type }}
     {{- if eq .Values.updateStrategy.type "Recreate" }}
     rollingUpdate: null
     {{- end }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -326,6 +326,8 @@ imagePullSecrets:
 
 # The update strategy for deployments with persistent volumes(jobservice, registry
 # and chartmuseum): "RollingUpdate" or "Recreate"
+# This is disabled for registry and chartmuseum when
+# persistence.imageChartStorage.type	is not set to "filesystem"
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
This fixes a bug that when using s3, etc to store images and charts the helm chart still sets a strategy for the helm chart when it isn't nessecary.