### PR TITLE
allow extraVolumes and extraVolumeMounts on core

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -124,6 +124,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+{{- with .Values.core.extraVolumeMounts }}
+{{ tpl (. | toYaml) $ | indent 8 }}
+{{- end }}
 {{- if .Values.core.resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -177,6 +180,9 @@ spec:
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
+{{- with .Values.core.extraVolumes }}
+{{ tpl (. | toYaml) $ | indent 6 }}
+{{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -434,6 +434,16 @@ core:
   secretName: ""
   # The XSRF key. Will be generated automatically if it isn't specified
   xsrfKey: ""
+  # Extra volumes to add to the container, e.g.:
+  #  - name: registry-data
+  #    persistentVolumeClaim:
+  #      claimName: nfs-harbor-registry-pvc
+  extraVolumes: []
+  # Extra volume mounts to add to the container, e.g.:
+  #  - mountPath: /data
+  #    name: registry-data
+  #    subPath: core
+  extraVolumeMounts: []
 
 jobservice:
   image:


### PR DESCRIPTION
We've deployed harbor using helm 3 on a 1.18 Kubernetes cluster:

```
NAME  	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART       	APP VERSION
harbor	harbor   	7       	2021-03-24 10:36:22.909063483 +0000 UTC	deployed	harbor-1.6.0	2.2.0      
```
Our storage for the registry, chartmuseum and jobservice is a NFS (ReadWriteMany) solution.

When we access the GUI, the storage gauge on the right appears with a NaN GB.

When using a ReadWriteMany storage solution, I believe this solves this issue: API api/systeminfo/volumes does't work #441 

By mounting the same storage as extraVolume on the core component:

```
core:
  image:
    repository: goharbor/harbor-core
    tag: v2.2.0
    ...
    # Extra volumes to add to the deployment
    extraVolumes:
      - name: registry-data
        persistentVolumeClaim:
          claimName: nfs-harbor-dev-pvc
    # Extra volume mounts to add to the container
    extraVolumeMounts:
      - mountPath: /data
        name: registry-data
        subPath: core
```

Thanks,
Manuel