### PR TITLE
Use release name as full name if it contains chart name

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -31,7 +31,7 @@ Configure the new chart to make sure that the configuration items have the same 
     kubectl get secret
     ```
 
-    Find the secret whose name ends with `-harbor-ingress` (expose service via `Ingress`) or `-harbor-nginx`(expose service via `ClusterIP` or `NodePort`)
+    Find the secret whose name ends with `-ingress` (expose service via `Ingress`) or `-harbor-nginx`(expose service via `ClusterIP` or `NodePort`)
 
 2) Export the secret as yaml file:
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -10,11 +10,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "harbor.fullname" -}}
-{{- $name := default "harbor" .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "harbor" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/* Helm required labels */}}
 {{- define "harbor.labels" -}}

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -13,8 +13,8 @@ type IngressTestSuite struct {
 }
 
 func (i *IngressTestSuite) TestIngress() {
-	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-harbor-ingress", i.ReleaseName))
-	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-harbor-ingress-notary", i.ReleaseName))
+	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-ingress", i.ReleaseName))
+	k8s.GetIngress(i.T(), i.Options.KubectlOptions, fmt.Sprintf("%s-ingress-notary", i.ReleaseName))
 }
 
 func TestIngressTestSuite(t *testing.T) {


### PR DESCRIPTION
Updated to match all the currently generated helm fullname templates.