### PR TITLE
add custom annotation support for harbor and notary ingresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `expose.ingress.hosts.core` | The host of Harbor core service in ingress rule | `core.harbor.domain` |
 | `expose.ingress.hosts.notary` | The host of Harbor Notary service in ingress rule | `notary.harbor.domain` |
 | `expose.ingress.controller` | The ingress controller type. Currently supports `default`, `gce` and `ncp` | `default` |
-| `expose.ingress.annotations` | The annotations used in ingress |  |
+| `expose.ingress.annotations` | The annotations used commonly for ingresses |  |
+| `expose.ingress.harbor.annotations` | The annotations specific to harbor ingress | {} |
+| `expose.ingress.notary.annotations` | The annotations specific to notary ingress | {} |
 | `expose.clusterIP.name` | The name of ClusterIP service | `harbor` |
 | `expose.clusterIP.annotations` | The annotations attached to the ClusterIP service | {} |
 | `expose.clusterIP.ports.httpPort` | The service port Harbor listens on when serving with HTTP | `80` |

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -51,6 +51,7 @@ metadata:
     ncp/http-redirect: "true"
     {{- end }}
 {{- end }}
+{{ toYaml $ingress.harbor.annotations | indent 4 }}
 spec:
   {{- if $tls.enabled }}
   tls:
@@ -158,6 +159,7 @@ metadata:
     ncp/http-redirect: "true"
     {{- end }}
 {{- end }}
+{{ toYaml $ingress.notary.annotations | indent 4 }}
 spec:
   {{- if $tls.enabled }}
   tls:

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -51,7 +51,9 @@ metadata:
     ncp/http-redirect: "true"
     {{- end }}
 {{- end }}
+{{- if $ingress.harbor.annotations }}
 {{ toYaml $ingress.harbor.annotations | indent 4 }}
+{{- end }}
 spec:
   {{- if $tls.enabled }}
   tls:
@@ -159,7 +161,9 @@ metadata:
     ncp/http-redirect: "true"
     {{- end }}
 {{- end }}
+{{- if $ingress.notary.annotations }}
 {{ toYaml $ingress.notary.annotations | indent 4 }}
+{{- end }}
 spec:
   {{- if $tls.enabled }}
   tls:

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,12 @@ expose:
       ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    notary:
+      # notary-specific annotations
+      annotations: {}
+    harbor:
+      # harbor ingress-specific annotations
+      annotations: {}
   clusterIP:
     # The name of ClusterIP service
     name: harbor


### PR DESCRIPTION
Hi,
This PR includes the changes to helm chart for allowing custom annotations separately for harbor and notary ingresses as opened with the issue #915 

Following structure is the way to use it:
```
ingress:
  ...
  annotations: # common annotations for ingresses
  harbor:
    annotations: # custom annotations for harbor ingress
  notary:
    annotations: # custom annotations for notary ingress
```

Closes #915 