### PR TITLE
[cherry-pick]Ignore the .github folder when packaging Harbor chart

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,6 +1,6 @@
+.github/*
 docs/*
 .git/*
 .gitignore
 CONTRIBUTING.md
-.travis.yaml
 test/*


### PR DESCRIPTION
Signed-off-by: Wenkai Yin <yinw@vmware.com>