### PR TITLE
Fix the metric portname in servicemonitor

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -530,3 +530,11 @@ postgres://{{ template "harbor.database.username" . }}:{{ template "harbor.datab
     {{- include "harbor.nginx" . -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "harbor.metricsPortName" -}}
+  {{- if .Values.internalTLS.enabled }}
+    {{- printf "https-metrics" -}}
+  {{- else -}}
+    {{- printf "http-metrics" -}}
+  {{- end -}}
+{{- end -}}

--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -13,7 +13,7 @@ spec:
       port: {{ template "harbor.core.servicePort" . }}
       targetPort: {{ template "harbor.core.containerPort" . }}
 {{- if .Values.metrics.enabled}}
-    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
+    - name: {{ template "harbor.metricsPortName" . }}
       port: {{ .Values.metrics.core.port }}
 {{- end }}
   selector:

--- a/templates/exporter/exporter-svc.yaml
+++ b/templates/exporter/exporter-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
+    - name: {{ template "harbor.metricsPortName" . }}
       port: {{ .Values.metrics.exporter.port }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}

--- a/templates/jobservice/jobservice-svc.yaml
+++ b/templates/jobservice/jobservice-svc.yaml
@@ -10,7 +10,7 @@ spec:
       port: {{ template "harbor.jobservice.servicePort" . }}
       targetPort: {{ template "harbor.jobservice.containerPort" . }}
 {{- if .Values.metrics.enabled }}
-    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
+    - name: {{ template "harbor.metricsPortName" . }}
       port: {{ .Values.metrics.jobservice.port }}
 {{- end }}
   selector:

--- a/templates/metrics/metrics-svcmon.yaml
+++ b/templates/metrics/metrics-svcmon.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   jobLabel: app.kubernetes.io/name
   endpoints:
-  - port: metrics
+  - port:  {{ template "harbor.metricsPortName" . }}
     {{- if .Values.metrics.serviceMonitor.interval }}
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     {{- end }}

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -12,7 +12,7 @@ spec:
     - name: {{ ternary "https-controller" "http-controller" .Values.internalTLS.enabled }}
       port: {{ template "harbor.registryctl.servicePort" . }}
 {{- if .Values.metrics.enabled}}
-    - name: {{ ternary "https-metrics" "http-metrics" .Values.internalTLS.enabled }}
+    - name: {{ template "harbor.metricsPortName" . }}
       port: {{ .Values.metrics.registry.port }}
 {{- end }}
   selector:


### PR DESCRIPTION
Fix the mismatch in the portname between servicemonitor and services.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>