### PR TITLE
Support "docker-registry" as the proxy cache registry

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -50,7 +50,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"


### PR DESCRIPTION
Support "docker-registry" as the proxy cache registry

Signed-off-by: Wenkai Yin <yinw@vmware.com>