### PR TITLE
fix permission after emergency shutdown kube workers

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -63,7 +63,7 @@ spec:
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chmod 700 /var/lib/postgresql/data/pgdata || true"]
+        args: ["-c", "chmod -R 700 /var/lib/postgresql/data/pgdata || true"]
 {{- if .Values.database.internal.initContainer.permissions.resources }}
         resources:
 {{ toYaml .Values.database.internal.initContainer.permissions.resources | indent 10 }}


### PR DESCRIPTION
Pod with database cannot start after emergency shutdown kubernetes workers when using longhorn