### PR TITLE
Allows db service to be exposed via external DNS

### DIFF
--- a/templates/database/database-svc.yaml
+++ b/templates/database/database-svc.yaml
@@ -3,11 +3,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.database" . }}"
+  annotations:
+    {{ with .Values.database.serviceAnnotations }}
+    {{- toYaml . | indent 4 }}
+    {{- end }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
     - port: 5432
+{{-if .Values.database.internal.headless }}
+  clusterIp: "None"
+{{- end }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
     component: database

--- a/values.yaml
+++ b/values.yaml
@@ -688,6 +688,8 @@ database:
     serviceAccountName: ""
     # mount the service account token
     automountServiceAccountToken: false
+    # if true, creates a headless service
+    headless: false
     image:
       repository: goharbor/harbor-db
       tag: dev
@@ -742,6 +744,8 @@ database:
   maxOpenConns: 900
   ## Additional deployment annotations
   podAnnotations: {}
+  ## Additional service annotations 
+  serviceAnnotations: {}
 
 redis:
   # if external Redis is used, set "type" to "external"


### PR DESCRIPTION
* Adds option for a headless db service
* Adds option for db service annotations

A user can expose the single pod db via external DNS by setting
headless to true and adding the external-DNS annotations to the service.

Signed-off-by: Jack Wink <57678801+mothershipper@users.noreply.github.com>