### PR TITLE
fix(ingress): Reorder portal path for AWS ALBs

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -67,10 +67,6 @@ spec:
   - http:
       paths:
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
-      - path: {{ .portal_path }}
-        backend:
-          serviceName: {{ template "harbor.portal" . }}
-          servicePort: {{ template "harbor.portal.servicePort" . }}
       - path: {{ .api_path }}
         backend:
           serviceName: {{ template "harbor.core" . }}
@@ -91,7 +87,46 @@ spec:
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .portal_path }}
+        backend:
+          serviceName: {{ template "harbor.portal" . }}
+          servicePort: {{ template "harbor.portal.servicePort" . }}
 {{- else }}
+      - path: {{ .api_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .service_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .v2_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .chartrepo_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .controller_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .portal_path }}
         pathType: Prefix
         backend:
@@ -99,41 +134,6 @@ spec:
             name: {{ template "harbor.portal" . }}
             port:
               number: {{ template "harbor.portal.servicePort" . }}
-      - path: {{ .api_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .service_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .v2_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .chartrepo_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .controller_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
 {{- end }}
     {{- if $ingress.hosts.core }}
     host: {{ $ingress.hosts.core }}


### PR DESCRIPTION
AWS Load Balancer rules are evaluated in priority order, highest to
lowest from top to bottom. This change moves the all-matching / prefix
rule to the bottom of the list to unmask the more specific core paths.
This allows use of an AWS Load Balancer with Harbor.

Previously, all requests, even those matching core paths like /v2, would
be routed to the portal service because the portal path was evaluated as
the highest priority rule.

This address Issue https://github.com/goharbor/harbor-helm/issues/946