### PR TITLE
Bump up kind version to avoid CI failure

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.1.0
         with:
-          version: v0.9.0
+          version: v0.11.1
           node_image: kindest/node:${{ matrix.k8s_version }}
           cluster_name: kind-cluster-${{ matrix.k8s_version }}
           config: test/integration/kind-cluster.yaml


### PR DESCRIPTION
Bump up kind version to 0.11.1 to avoid CI failure

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>