### PR TITLE
Config overwrite json support

### DIFF
--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -16,3 +16,6 @@ data:
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
   CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
+{{-  if .Values.configOverwriteJSON.enbaled }}
+  CONFIG_OVERWRITE_JSON: {{ tpl .Values.configOverwriteJSON.config . }}
+{{- end }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -16,6 +16,6 @@ data:
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
   CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
-{{-  if .Values.configOverwriteJSON.enbaled }}
+{{-  if .Values.configOverwriteJSON.enabled }}
   CONFIG_OVERWRITE_JSON: {{ tpl .Values.configOverwriteJSON.config . }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -374,6 +374,12 @@ proxy:
 # contains a base64 encoded CA Certificate named `ca.crt`.
 # uaaSecretName:
 
+# Configure Harbor settings as a single JSON object containing values for the `/api/v2.0/configurations` endpoint.
+# { "auth_mode": "oidc_auth", "oidc_auto_onboard": "true", ... }
+configOverwriteJSON:
+  enabled: false
+  config: ""
+
 # If expose the service via "ingress", the Nginx will not be used
 nginx:
   image:


### PR DESCRIPTION
This pull request aims to allow helm chart users to be able to specify CONFIG_OVERWRITE_JSON from within `values.yaml`.

See issue https://github.com/goharbor/harbor-helm/issues/1021