### PR TITLE
Allow GCS Workload Identity Authentication For Registry

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -36,7 +36,9 @@ data:
       {{- else if eq $type "gcs" }}
       gcs:
         bucket: {{ $storage.gcs.bucket }}
+        {{- if $storage.gcs.encodedkey }}
         keyfile: /etc/registry/gcs-key.json
+        {{- end }}
         {{- if $storage.gcs.rootdirectory }}
         rootdirectory: {{ $storage.gcs.rootdirectory }}
         {{- end }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -110,9 +110,11 @@ spec:
           mountPath: /etc/harbor/ssl/registry
         {{- end }}
         {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "gcs") }}
+        {{- if .Values.persistence.imageChartStorage.gcs.encodedkey }}
         - name: gcs-key
           mountPath: /etc/registry/gcs-key.json
           subPath: gcs-key.json
+        {{- end }}
         {{- end }}
         {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
         - name: storage-service-ca

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -204,9 +204,11 @@ spec:
           subPath: ca.crt
         {{- end }}
         {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "gcs") }}
+        {{- if .Values.persistence.imageChartStorage.gcs.encodedkey }}
         - name: gcs-key
           mountPath: /etc/registry/gcs-key.json
           subPath: gcs-key.json
+        {{- end }}
         {{- end }}
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
@@ -234,12 +236,14 @@ spec:
           secretName: {{ template "harbor.internalTLS.registry.secretName" . }}
       {{- end }}
       {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "gcs") }}
+      {{- if .Values.persistence.imageChartStorage.gcs.encodedkey }}
       - name: gcs-key
         secret:
           secretName: {{ template "harbor.registry" . }}
           items:
             - key: GCS_KEY_DATA
               path: gcs-key.json
+      {{- end }}
       {{- end }}
       {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
       - name: storage-service-ca

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -13,7 +13,9 @@ data:
   {{- if eq $type "azure" }}
   REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $storage.azure.accountkey | b64enc | quote }}
   {{- else if eq $type "gcs" }}
+  {{- if $storage.gcs.encodedkey }}
   GCS_KEY_DATA: {{ $storage.gcs.encodedkey | quote }}
+  {{- end }}
   {{- else if eq $type "s3" }}
   {{- if $storage.s3.accesskey }}
   REGISTRY_STORAGE_S3_ACCESSKEY: {{ $storage.s3.accesskey | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -281,7 +281,8 @@ persistence:
     gcs:
       bucket: bucketname
       # The base64 encoded json file which contains the key
-      encodedkey: base64-encoded-json-key-file
+      # If encodedkey is unset and GCS enabled it defaults to service account authentication for workload identity
+      #encodedkey: base64-encoded-json-key-file
       #rootdirectory: /gcs/object/name/prefix
       #chunksize: "5242880"
     s3:


### PR DESCRIPTION
The GCS registry driver supports workload idenity if the keyfile is unspecified. I tested this and it works fine. This allows you to specify no keyfile and instead allows application default credentials to authenticate for you with workload identity.