### PR TITLE
add secret which has certificate and key to connect with the database

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -45,6 +45,12 @@ spec:
       - name: core
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ['sh', '-c', 'cp /db/certs/..data/* /certs; chmod -R 600 /certs; ls -al /certs']
+        {{- end }}
         {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
           httpGet:
@@ -95,6 +101,14 @@ spec:
           - name: INTERNAL_TLS_TRUST_CA_PATH
             value: /etc/harbor/ssl/core/ca.crt
          {{- end }}
+         {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+          - name: PGSSLCERT
+            value: /certs/harbor-client-cert.pem
+          - name: PGSSLKEY
+            value: /certs/harbor-client-key.pem
+          - name: PGSSLROOTCERT
+            value: /certs/harbor-ca-cert.pem
+        {{- end }}
         ports:
         - containerPort: {{ template "harbor.core.containerPort" . }}
         volumeMounts:
@@ -122,6 +136,12 @@ spec:
         {{- end }}
         - name: psc
           mountPath: /etc/core/token
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: db-certs-keys
+          mountPath: /db/certs
+        - name: certs
+          mountPath: /certs
+        {{- end }}
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
@@ -175,6 +195,18 @@ spec:
       {{- end }}
       - name: psc
         emptyDir: {}
+      {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+      - name: db-certs-keys
+        secret:
+          {{- if not .Values.database.external.secretNameCertsKeys }}
+          secretName: db-cert-key
+          {{- else }}
+          secretName: {{ .Values.database.external.secretNameCertsKeys }}
+          {{- end }}
+          defaultMode: 400
+      - name: certs
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}

--- a/templates/core/db-cert-key-secret.yaml
+++ b/templates/core/db-cert-key-secret.yaml
@@ -1,0 +1,15 @@
+{{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+{{- if not .Values.database.external.secretNameCertsKeys }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-cert-key
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+type: Opaque
+data:
+  harbor-ca-cert.pem: {{ .Values.database.external.certskeys.rootCert }}
+  harbor-client-cert.pem: {{ .Values.database.external.certskeys.clientCert }}
+  harbor-client-key.pem: {{ .Values.database.external.certskeys.clientKey }}
+{{- end }}
+{{- end }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -51,6 +51,12 @@ spec:
       - name: jobservice
         image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ['sh', '-c', 'cp /db/certs/..data/* /certs; chmod -R 600 /certs; ls -al /certs']
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v1/stats
@@ -85,6 +91,14 @@ spec:
           - name: INTERNAL_TLS_TRUST_CA_PATH
             value: /etc/harbor/ssl/jobservice/ca.crt
           {{- end }}
+          {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+          - name: PGSSLCERT
+            value: /certs/harbor-client-cert.pem
+          - name: PGSSLKEY
+            value: /certs/harbor-client-key.pem
+          - name: PGSSLROOTCERT
+            value: /certs/harbor-ca-cert.pem
+        {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.jobservice" . }}-env"
@@ -102,6 +116,12 @@ spec:
         {{- if .Values.internalTLS.enabled }}
         - name: jobservice-internal-certs
           mountPath: /etc/harbor/ssl/jobservice
+        {{- end }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: db-certs-keys
+          mountPath: /db/certs
+        - name: certs
+          mountPath: /certs
         {{- end }}
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
@@ -121,6 +141,18 @@ spec:
       - name: jobservice-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.jobservice.secretName" . }}
+      {{- end }}
+      {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+      - name: db-certs-keys
+        secret:
+          {{- if not .Values.database.external.secretNameCertsKeys }}
+          secretName: db-cert-key
+          {{- else }}
+          secretName: {{ .Values.database.external.secretNameCertsKeys }}
+          {{- end }}
+          defaultMode: 400
+      - name: certs
+        emptyDir: {}
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -39,6 +39,12 @@ spec:
       - name: notary-server
         image: {{ .Values.notary.server.image.repository }}:{{ .Values.notary.server.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ['sh', '-c', 'cp /db/certs/..data/* /certs; chmod -R 600 /certs; ls -al /certs']
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /_notary_server/health
@@ -62,6 +68,14 @@ spec:
           value: migrations/server/postgresql
         - name: DB_URL
           value: {{ template "harbor.database.notaryServer" . }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: PGSSLCERT
+          value: /certs/harbor-client-cert.pem
+        - name: PGSSLKEY
+          value: /certs/harbor-client-key.pem
+        - name: PGSSLROOTCERT
+          value: /certs/harbor-ca-cert.pem
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/notary/server-config.postgres.json
@@ -72,6 +86,12 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/ca.crt
           subPath: ca.crt
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: db-certs-keys
+          mountPath: /db/certs
+        - name: certs
+          mountPath: /certs
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -90,6 +110,18 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+      - name: db-certs-keys
+        secret:
+          {{- if not .Values.database.external.secretNameCertsKeys }}
+          secretName: db-cert-key
+          {{- else }}
+          secretName: {{ .Values.database.external.secretNameCertsKeys }}
+          {{- end }}
+          defaultMode: 400
+      - name: certs
+        emptyDir: {}
+      {{- end }}
     {{- with .Values.notary.server.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -38,6 +38,12 @@ spec:
       - name: notary-signer
         image: {{ .Values.notary.signer.image.repository }}:{{ .Values.notary.signer.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ['sh', '-c', 'cp /db/certs/..data/* /certs; chmod -R 600 /certs; ls -al /certs']
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /
@@ -63,6 +69,14 @@ spec:
           value: {{ template "harbor.database.notarySigner" . }}
         - name: NOTARY_SIGNER_DEFAULTALIAS
           value: defaultalias
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: PGSSLCERT
+          value: /certs/harbor-client-cert.pem
+        - name: PGSSLKEY
+          value: /certs/harbor-client-key.pem
+        - name: PGSSLROOTCERT
+          value: /certs/harbor-ca-cert.pem
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/notary/signer-config.postgres.json
@@ -73,6 +87,12 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/tls.key
           subPath: tls.key
+        {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+        - name: db-certs-keys
+          mountPath: /db/certs
+        - name: certs
+          mountPath: /certs
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -84,6 +104,18 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if or (eq .Values.database.external.sslmode "require") (eq .Values.database.external.sslmode "verify-ca") (eq .Values.database.external.sslmode "verify-full") }}
+      - name: db-certs-keys
+        secret:
+          {{- if not .Values.database.external.secretNameCertsKeys }}
+          secretName: db-cert-key
+          {{- else }}
+          secretName: {{ .Values.database.external.secretNameCertsKeys }}
+          {{- end }}
+          defaultMode: 400
+      - name: certs
+        emptyDir: {}
+      {{- end }}
     {{- with .Values.notary.signer.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -743,6 +743,13 @@ database:
     # server was signed by a trusted CA and the server host name matches the one
     # in the certificate)
     sslmode: "disable"
+    # The name of the secret containing the certificate and key with literal, "harbor-ca-cert.pem", "harbor-client-cert.pem" & "harbor-client-key.pem", or providing the base64 encoded secret of the certificate and key..
+    secretNameCertsKeys: 
+    # The base64 encoded certificate and key if the name of the secret containing the certificate and key is not provided.
+    certskeys:
+      rootCert: 
+      clientCert: 
+      clientKey: 
   # The maximum number of connections in the idle connection pool per pod (core+exporter).
   # If it <=0, no idle connections are retained.
   maxIdleConns: 100


### PR DESCRIPTION
- added secret which will have db cert and key to connect when using sslmode other than disable.
- updated deployments of core, jobservice, notarysigner & notarysecret with volumemounts and volumes for the db cert key secret.
- added poststart lifecycle hook in deployments of core, jobservice, notarysigner & notarysecret which will change the permissions of the cert and key and will move into the emptydir volume and from that the env `PGSSLROOTCERT`, `PGSSLCERT` & `PGSSLKEY` will pick up the cert and key from the emptydir volume.