### PR TITLE
Update prerequisite for helm version in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This [Helm](https://github.com/kubernetes/helm) chart installs [Harbor](https://
 ## Prerequisites
 
 - Kubernetes cluster 1.20+
-- Helm v3
+- Helm v3.2.0+
 
 ## Installation
 

--- a/docs/High Availability.md
+++ b/docs/High Availability.md
@@ -9,7 +9,7 @@ Deploy Harbor on K8S via helm to make it highly available, that is, if one of no
 ## Prerequisites
 
 - Kubernetes cluster 1.20+
-- Helm v3
+- Helm v3.2.0+
 - High available ingress controller (Harbor does not manage the external endpoint)
 - High available PostgreSQL database (Harbor does not handle the deployment of HA of database)
 - High available Redis (Harbor does not handle the deployment of HA of Redis)


### PR DESCRIPTION
The "htpasswd" function used by harbor chart is supported by helm v3.2.0+, update the prerequisite for this in doc

Fixes #1070

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>