### PR TITLE
Pin jenkins shared library to version 2.4

### DIFF
--- a/test/e2e/Jenkinsfile
+++ b/test/e2e/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('harbor@main') _
+@Library('harbor@2.4') _
 import io.goharbor.*
 
 class HarborChartFreshInstallPipelineExecutor extends FreshInstallPipelineExecutor implements Serializable {
@@ -101,7 +101,6 @@ def properties = {
 
 def caseSettings = {
     CaseSettings settings = new CaseSettings()
-    settings.branch = "master"// change the branch to the specific one when releases new version
     settings.cases = "gc,common,database,trivy,notary,chartmuseum"
     return settings
 }


### PR DESCRIPTION
1. Pin jenkins shared library to version 2.4
2. Remove the setting for case branch as it is already pinned in the jenins shared library. Remove it so that we don't need to update it for every major release

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>