### PR TITLE
Remove the case branch setting

### DIFF
--- a/test/e2e/Jenkinsfile
+++ b/test/e2e/Jenkinsfile
@@ -101,7 +101,6 @@ def properties = {
 
 def caseSettings = {
     CaseSettings settings = new CaseSettings()
-    settings.branch = "master"// change the branch to the specific one when releases new version
     settings.cases = "gc,common,database,trivy,notary,chartmuseum"
     return settings
 }


### PR DESCRIPTION
Remove the setting for case branch as it is already pinned in the jenins shared library.

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>