### PR TITLE
change v2 path for default ingress

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -21,7 +21,7 @@
   {{- $_ := set . "portal_path" "/" -}}
   {{- $_ := set . "api_path" "/api/" -}}
   {{- $_ := set . "service_path" "/service/" -}}
-  {{- $_ := set . "v2_path" "/v2" -}}
+  {{- $_ := set . "v2_path" "/v2/" -}}
   {{- $_ := set . "chartrepo_path" "/chartrepo/" -}}
   {{- $_ := set . "controller_path" "/c/" -}}
   {{- $_ := set . "notary_path" "/" -}}


### PR DESCRIPTION
the lack of trailing slash on /v2 path for default ingress cause ssl redirection trouble

if someone ask http://registry/v2/ redirect give https://registry/v2 who failed to authenticate