### PR TITLE
Move portal at the end of the ingress paths

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -70,10 +70,6 @@ spec:
   - http:
       paths:
 {{- if semverCompare "<1.19-0" (include "harbor.ingress.kubeVersion" .) }}
-      - path: {{ .portal_path }}
-        backend:
-          serviceName: {{ template "harbor.portal" . }}
-          servicePort: {{ template "harbor.portal.servicePort" . }}
       - path: {{ .api_path }}
         backend:
           serviceName: {{ template "harbor.core" . }}
@@ -94,7 +90,46 @@ spec:
         backend:
           serviceName: {{ template "harbor.core" . }}
           servicePort: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .portal_path }}
+        backend:
+          serviceName: {{ template "harbor.portal" . }}
+          servicePort: {{ template "harbor.portal.servicePort" . }}
 {{- else }}
+      - path: {{ .api_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .service_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .v2_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .chartrepo_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .controller_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.core" . }}
+            port:
+              number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .portal_path }}
         pathType: Prefix
         backend:
@@ -102,41 +137,6 @@ spec:
             name: {{ template "harbor.portal" . }}
             port:
               number: {{ template "harbor.portal.servicePort" . }}
-      - path: {{ .api_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .service_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .v2_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .chartrepo_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
-      - path: {{ .controller_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.core" . }}
-            port:
-              number: {{ template "harbor.core.servicePort" . }}
 {{- end }}
     {{- if $ingress.hosts.core }}
     host: {{ $ingress.hosts.core }}


### PR DESCRIPTION
According to the ingress specification [1], the longest matching path should
be used. But for Istio, "The first rule matching an incoming request is
used" [2],[3].

[1]: https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches
[2]: https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService
[3]: https://github.com/istio/istio/issues/35033

Fixes: #485
Signed-off-by: Mathieu Parent <math.parent@gmail.com>