### PR TITLE
Fix Ingress ordering where non-root (non-portal) requests are being routed to portal service

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -95,13 +95,6 @@ spec:
           serviceName: {{ template "harbor.core" . }}
           servicePort: {{ template "harbor.core.servicePort" . }}
 {{- else }}
-      - path: {{ .portal_path }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "harbor.portal" . }}
-            port:
-              number: {{ template "harbor.portal.servicePort" . }}
       - path: {{ .api_path }}
         pathType: Prefix
         backend:
@@ -137,6 +130,13 @@ spec:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
+      - path: {{ .portal_path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "harbor.portal" . }}
+            port:
+              number: {{ template "harbor.portal.servicePort" . }}
 {{- end }}
     {{- if $ingress.hosts.core }}
     host: {{ $ingress.hosts.core }}


### PR DESCRIPTION
This fixes the 405:Method Not Allowed bug, primarily with ALB Ingress controller on Kubernetes >1.19.