### PR TITLE
Add ability to configure an existing secret for S3 type storage

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -69,7 +69,7 @@ data:
   {{- if $storage.s3.regionendpoint }}
   STORAGE_AMAZON_ENDPOINT: {{ $storage.s3.regionendpoint }}
   {{- end }}
-  {{- if $storage.s3.accesskey }}
+  {{- if and (not $storage.s3.existingSecret) ($storage.s3.accesskey) }}
   AWS_ACCESS_KEY_ID: {{ $storage.s3.accesskey }}
   {{- end }}
   {{- if $storage.s3.keyid }}

--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -74,6 +74,10 @@ spec:
             name: "{{ template "harbor.chartmuseum" . }}"
         - secretRef:
             name: "{{ template "harbor.chartmuseum" . }}"
+        {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
         env:
           {{- if has "chartmuseum" .Values.proxy.components }}
           - name: HTTP_PROXY

--- a/templates/chartmuseum/chartmuseum-secret.yaml
+++ b/templates/chartmuseum/chartmuseum-secret.yaml
@@ -15,7 +15,7 @@ data:
 {{- else if eq $storageType "gcs" }}
   # TODO support the keyfile of gcs
 {{- else if eq $storageType "s3" }}
-  {{- if $storage.s3.secretkey }}
+  {{- if and (not $storage.s3.existingSecret) ($storage.s3.secretkey) }}
   AWS_SECRET_ACCESS_KEY: {{ $storage.s3.secretkey | b64enc | quote }}
   {{- end }}
 {{- else if eq $storageType "swift" }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -74,6 +74,10 @@ spec:
         envFrom:
         - secretRef:
             name: "{{ template "harbor.registry" . }}"
+        {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
         env:
         {{- if has "registry" .Values.proxy.components }}
         - name: HTTP_PROXY

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -15,10 +15,10 @@ data:
   {{- else if eq $type "gcs" }}
   GCS_KEY_DATA: {{ $storage.gcs.encodedkey | quote }}
   {{- else if eq $type "s3" }}
-  {{- if $storage.s3.accesskey }}
+  {{- if and (not $storage.s3.existingSecret) ($storage.s3.accesskey) }}
   REGISTRY_STORAGE_S3_ACCESSKEY: {{ $storage.s3.accesskey | b64enc | quote }}
   {{- end }}
-  {{- if $storage.s3.secretkey }}
+  {{- if and (not $storage.s3.existingSecret) ($storage.s3.secretkey) }}
   REGISTRY_STORAGE_S3_SECRETKEY: {{ $storage.s3.secretkey | b64enc | quote }}
   {{- end }}
   {{- else if eq $type "swift" }}

--- a/values.yaml
+++ b/values.yaml
@@ -298,6 +298,9 @@ persistence:
       #rootdirectory: /gcs/object/name/prefix
       #chunksize: "5242880"
     s3:
+      # Set an existing secret for S3 accesskey and secretkey
+      # keys in the secret should be AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      #existingSecret: ""
       region: us-west-1
       bucket: bucketname
       #accesskey: awsaccesskey

--- a/values.yaml
+++ b/values.yaml
@@ -299,7 +299,8 @@ persistence:
       #chunksize: "5242880"
     s3:
       # Set an existing secret for S3 accesskey and secretkey
-      # keys in the secret should be AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      # keys in the secret should be AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for chartmuseum
+      # keys in the secret should be REGISTRY_STORAGE_S3_ACCESSKEY and REGISTRY_STORAGE_S3_SECRETKEY for registry
       #existingSecret: ""
       region: us-west-1
       bucket: bucketname


### PR DESCRIPTION
In the GitOps world, it's a good practice to separate the configuration of secrets from the actual application Helm chart. 

Using secrets provisioned differently (for example with https://external-secrets.io/) makes it much easier to manage the lifecycle of a secret without the headache of "How would I securely inject my secret with Helm during CD?".

Although this PR only aims to fix that for the `persistence.imageChartStorage.s3` use case, it might encourage others to do the same for other `imageChartStorage` cases.

