### PR TITLE
chore: Configurable caCert and clientCerts validity

### DIFF
--- a/templates/ingress/secret.yaml
+++ b/templates/ingress/secret.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
-{{- $ca := genCA "harbor-ca" 365 }}
-{{- $cert := genSignedCert .Values.expose.ingress.hosts.core nil (list .Values.expose.ingress.hosts.core .Values.expose.ingress.hosts.notary) 365 $ca }}
+{{- $ca := genCA "harbor-ca" .Values.internalTLS.certValidity.caCert }}
+{{- $cert := genSignedCert .Values.expose.ingress.hosts.core nil (list .Values.expose.ingress.hosts.core .Values.expose.ingress.hosts.notary) .Values.internalTLS.certValidity.clientCert $ca }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/internal/auto-tls.yaml
+++ b/templates/internal/auto-tls.yaml
@@ -1,13 +1,13 @@
 {{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "auto") }}
-{{- $ca := genCA "harbor-internal-ca" 365 }}
+{{- $ca := genCA "harbor-internal-ca" .Values.internalTLS.certValidity.caCert }}
 {{- $coreCN := (include "harbor.core" .) }}
-{{- $coreCrt := genSignedCert $coreCN (list "127.0.0.1") (list "localhost" $coreCN) 365 $ca }}
+{{- $coreCrt := genSignedCert $coreCN (list "127.0.0.1") (list "localhost" $coreCN) .Values.internalTLS.certValidity.clientCert $ca }}
 {{- $jsCN := (include "harbor.jobservice" .) }}
-{{- $jsCrt := genSignedCert $jsCN nil (list $jsCN) 365 $ca }}
+{{- $jsCrt := genSignedCert $jsCN nil (list $jsCN) .Values.internalTLS.certValidity.clientCert $ca }}
 {{- $regCN := (include "harbor.registry" .) }}
-{{- $regCrt := genSignedCert $regCN nil (list $regCN) 365 $ca }}
+{{- $regCrt := genSignedCert $regCN nil (list $regCN) .Values.internalTLS.certValidity.clientCert $ca }}
 {{- $portalCN := (include "harbor.portal" .) }}
-{{- $portalCrt := genSignedCert $portalCN nil (list $portalCN) 365 $ca }}
+{{- $portalCrt := genSignedCert $portalCN nil (list $portalCN) .Values.internalTLS.certValidity.clientCert $ca }}
 
 ---
 apiVersion: v1
@@ -64,7 +64,7 @@ data:
 {{- if .Values.chartmuseum.enabled }}
 ---
 {{- $chartCN := (include "harbor.chartmuseum" .) }}
-{{- $chartCrt := genSignedCert $chartCN nil (list $chartCN) 365 $ca }}
+{{- $chartCrt := genSignedCert $chartCN nil (list $chartCN) .Values.internalTLS.certValidity.clientCert $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -81,7 +81,7 @@ data:
 {{- if and .Values.trivy.enabled}}
 ---
 {{- $trivyCN := (include "harbor.trivy" .) }}
-{{- $trivyCrt := genSignedCert $trivyCN nil (list $trivyCN) 365 $ca }}
+{{- $trivyCrt := genSignedCert $trivyCN nil (list $trivyCN) .Values.internalTLS.certValidity.clientCert $ca }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/nginx/secret.yaml
+++ b/templates/nginx/secret.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "harbor.autoGenCertForNginx" .) "true" }}
-{{- $ca := genCA "harbor-ca" 365 }}
+{{- $ca := genCA "harbor-ca" .Values.internalTLS.certValidity.caCert }}
 {{- $cn := (required "The \"expose.tls.auto.commonName\" is required!" .Values.expose.tls.auto.commonName) }}
 apiVersion: v1
 kind: Secret
@@ -10,12 +10,12 @@ metadata:
 type: Opaque
 data:
   {{- if regexMatch `^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$` $cn }}
-  {{- $cert := genSignedCert $cn (list $cn) nil 365 $ca }}
+  {{- $cert := genSignedCert $cn (list $cn) nil .Values.internalTLS.certValidity.clientCert $ca }}
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
-  {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
+  {{- $cert := genSignedCert $cn nil (list $cn) .Values.internalTLS.certValidity.clientCert $ca }}
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}

--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -9,8 +9,8 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.notary.secretName }}
-  {{- $ca := genCA "harbor-notary-ca" 365 }}
-  {{- $cert := genSignedCert (include "harbor.notary-signer" .) nil (list (include "harbor.notary-signer" .)) 365 $ca }}
+  {{- $ca := genCA "harbor-notary-ca" .Values.internalTLS.certValidity.caCert }}
+  {{- $cert := genSignedCert (include "harbor.notary-signer" .) nil (list (include "harbor.notary-signer" .)) .Values.internalTLS.certValidity.clientCert $ca }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -138,6 +138,12 @@ internalTLS:
   certSource: "auto"
   # The content of trust ca, only available when `certSource` is "manual"
   trustCa: ""
+  certValidity:
+    # Number of days self-signed certificate is valid
+    caCert: 365
+    # CA certificate validity in days
+    clientCert: 365
+    # Client certificate validity in days
   # core related cert configuration
   core:
     # secret name for core's tls certs


### PR DESCRIPTION
CA and Client Certificates have hardcoded 365 days of validity.

This merge request aims to make it configurable.