### PR TITLE
fixed a bug when setting CA bundle

### DIFF
--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -109,6 +109,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "harbor.trivy" . }}
                   key: redisURL
+            {{- if .Values.caBundleSecretName }}
+            - name: "SSL_CERT_DIR"
+              value: /harbor_cust_cert
+            {{- end }}
           ports:
             - name: api-server
               containerPort: {{ template "harbor.trivy.containerPort" . }}


### PR DESCRIPTION
encountered a bug in my environment that when a custom CA bundle was being used Trivy did not pick it up. let me know if this change works or if you guys want to do it a different way. 