### PR TITLE
fix: Added controller `alb` and used NodePort type instead of ClusterIP

### DIFF
--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
-{{- if  (eq .Values.expose.ingress.controller "gce") }}
+{{- if  (or (eq .Values.expose.ingress.controller "gce") (eq .Values.expose.ingress.controller "alb")) }}
   type: NodePort
 {{- end }}
   ports:

--- a/templates/notary/notary-svc.yaml
+++ b/templates/notary/notary-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
-{{- if  (eq .Values.expose.ingress.controller "gce") }}
+{{- if  (or (eq .Values.expose.ingress.controller "gce") (eq .Values.expose.ingress.controller "alb")) }}
   type: NodePort
 {{- end }}
   ports:

--- a/templates/portal/service.yaml
+++ b/templates/portal/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
-{{- if  (eq .Values.expose.ingress.controller "gce") }}
+{{- if  (or (eq .Values.expose.ingress.controller "gce") (eq .Values.expose.ingress.controller "alb")) }}
   type: NodePort
 {{- end }}
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,7 @@ expose:
     # set to the type of ingress controller if it has specific requirements.
     # leave as `default` for most ingress controllers.
     # set to `gce` if using the GCE ingress controller
+    # set to `alb` if using the ALB controller
     # set to `ncp` if using the NCP (NSX-T Container Plugin) ingress controller
     controller: default
     ## Allow .Capabilities.KubeVersion.Version to be overridden while creating ingress


### PR DESCRIPTION
with an ALB controller, the services must be of type NodePort (see. https://coresolutions.ltd/blog/kubernetes-aws-load-balancer-controller/)