### PR TITLE
Add S3-like Self-signed Storage Backend support for Chart Museum

### DIFF
--- a/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/templates/chartmuseum/chartmuseum-cm.yaml
@@ -69,6 +69,9 @@ data:
   {{- if $storage.s3.regionendpoint }}
   STORAGE_AMAZON_ENDPOINT: {{ $storage.s3.regionendpoint }}
   {{- end }}
+  {{- if $storage.s3.skipverify }}
+  AWS_INSECURE_SKIP_VERIFY: "true"
+  {{- end }}
   {{- if and (not $storage.s3.existingSecret) ($storage.s3.accesskey) }}
   AWS_ACCESS_KEY_ID: {{ $storage.s3.accesskey }}
   {{- end }}


### PR DESCRIPTION
Add `AWS_INSECURE_SKIP_VERIFY` env variable to Chart Museum Config Map for support Self Signed S3-like Object Storage scenario

Fixes #1217 