### PR TITLE
feat: Make registry work with Istio mTLS

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -544,14 +544,6 @@ postgres://{{ template "harbor.database.username" . }}:{{ template "harbor.datab
   {{- end -}}
 {{- end -}}
 
-{{- define "harbor.metricsPortName" -}}
-  {{- if .Values.internalTLS.enabled }}
-    {{- printf "https-metrics" -}}
-  {{- else -}}
-    {{- printf "http-metrics" -}}
-  {{- end -}}
-{{- end -}}
-
 {{- define "harbor.traceEnvs" -}}
   TRACE_ENABLED: "{{ .Values.trace.enabled }}"
   TRACE_SAMPLE_RATE: "{{ .Values.trace.sample_rate }}"

--- a/templates/exporter/exporter-svc.yaml
+++ b/templates/exporter/exporter-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: {{ template "harbor.metricsPortName" . }}
+    - name: metrics
       port: {{ .Values.metrics.exporter.port }}
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}

--- a/templates/redis/service.yaml
+++ b/templates/redis/service.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   ports:
     - port: 6379
+      name: redis
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
     component: redis

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   ports:
-    - name: {{ ternary "https-registry" "http-registry" .Values.internalTLS.enabled }}
+    - name: registry
       port: {{ template "harbor.registry.servicePort" . }}
 
     - name: {{ ternary "https-controller" "http-controller" .Values.internalTLS.enabled }}


### PR DESCRIPTION
Hey guys,

I have Harbor 2.5.2 working nicely with Istio mTLS, using a VirtualService instead of nginx, except for this _one_ issue.. (which is resolved by this PR).

So Istio uses service port names as a "hint" re [protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/).. if a service is named `http-<something>` or `https-<something>`, Istio will treat the traffic a certain way. If there's no name, or a name which doesn't match one of the pre-defined prefixes, Istio will treat the traffic as "tcp", and not try to do any clever HTTP parsing on it.

Now presumable registry's service on port 5000 is actually HTTP/S, but the envoy sidecar proxy doesn't particularly like the way core talks to registry (due to the host header), and so when using mTLS with the helm chart as-is, we see errors like this when pushing into the registry:

```
ERRO[0002] pushing image failed: pushing tag(s): GET https://registry.elpenguino.net/v2/: unexpected status code 503 Service Unavailable: upstream connect error or disconnect/reset before headers. reset reason: connection termination 
```

However, change the name of the registry service from `http-registry` or `https-registry` to simply `registry` (*or `bacon` if you like, provided it's not an Istio prefix*), and istio treats the traffic as TCP, and doesn't worry about parsing the HTTP.

So... this PR simply changes the name of the registry service port, which seems harmless to me, for the sake of mTLS compatibility. I'm happy to take input / suggestions from anyone more knowledgeable than me re the internals of either Harbor or Istio :)

For the record, I'm using the following VirtualService to mimic what nginx or the ingress does:

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  creationTimestamp: "2022-06-29T22:53:41Z"
  generation: 17
  labels:
    kustomize.toolkit.fluxcd.io/name: istio-system-elpenguino-net
    kustomize.toolkit.fluxcd.io/namespace: flux-system
  name: harbor
  namespace: harbor
  resourceVersion: "10596813"
  uid: 601d5907-e352-4604-9210-a67a7ab31485
spec:
  gateways:
  - istio-ingressgateway.istio-system.svc.cluster.local
  hosts:
  - registry.elpenguino.net
  http:
  - match:
    - uri:
        prefix: /api/
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - match:
    - uri:
        prefix: /service/
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - match:
    - uri:
        prefix: /chartrepo
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - match:
    - uri:
        prefix: /c/
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - match:
    - uri:
        prefix: /v1/
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - match:
    - uri:
        prefix: /v2/
    route:
    - destination:
        host: harbor-core
        port:
          number: 80
  - name: portal
    route:
    - destination:
        host: harbor-portal
        port:
          number: 80
    timeout: 30s
```