### PR TITLE
feat: Allow using preexisting secrets for sensitive data

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -74,9 +74,21 @@ spec:
             name: "{{ template "harbor.chartmuseum" . }}"
         - secretRef:
             name: "{{ template "harbor.chartmuseum" . }}"
+        {{- if .Values.persistence.imageChartStorage.azure.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.azure.existingSecret }}
+        {{- end }}
         {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
         - secretRef:
             name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.swift.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.swift.existingSecret }}
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.oss.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.oss.existingSecret }}
         {{- end }}
         env:
           {{- if has "chartmuseum" .Values.proxy.components }}
@@ -86,6 +98,13 @@ spec:
             value: "{{ .Values.proxy.httpsProxy }}"
           - name: NO_PROXY
             value: "{{ template "harbor.noProxy" . }}"
+          {{- end }}
+          {{- if .Values.redis.external.existingSecret }}
+          - name: CACHE_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.redis.external.existingSecret }}
+                key: name: {{ .Values.redis.external.existingSecretPasswordKey }}
           {{- end }}
           {{- if .Values.internalTLS.enabled }}
           - name: INTERNAL_TLS_ENABLED

--- a/templates/chartmuseum/chartmuseum-secret.yaml
+++ b/templates/chartmuseum/chartmuseum-secret.yaml
@@ -7,11 +7,15 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+{{- if not .Values.redis.external.existingSecret }}
   CACHE_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
+{{- end }}
 {{- $storage := .Values.persistence.imageChartStorage }}
 {{- $storageType := $storage.type }}
 {{- if eq $storageType "azure" }}
+  {{- if and (not $storage.azure.existingSecret) ($storage.azure.accountkey) }}
   AZURE_STORAGE_ACCESS_KEY: {{ $storage.azure.accountkey | b64enc | quote }}
+  {{- end }}
 {{- else if eq $storageType "gcs" }}
   # TODO support the keyfile of gcs
 {{- else if eq $storageType "s3" }}
@@ -19,8 +23,12 @@ data:
   AWS_SECRET_ACCESS_KEY: {{ $storage.s3.secretkey | b64enc | quote }}
   {{- end }}
 {{- else if eq $storageType "swift" }}
+  {{- if and (not $storage.swift.existingSecret) ($storage.swift.password) }}
   OS_PASSWORD: {{ $storage.swift.password | b64enc | quote }}
+  {{- end }}
 {{- else if eq $storageType "oss" }}
+  {{- if and (not $storage.oss.existingSecret) ($storage.oss.accesskeysecret) }}
   ALIBABA_CLOUD_ACCESS_KEY_SECRET: {{ $storage.oss.accesskeysecret | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -76,17 +76,57 @@ spec:
         - secretRef:
             name: "{{ template "harbor.core" . }}"
         env:
+          {{- if .Values.core.existingSecretSecret }}
           - name: CORE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "harbor.core" . }}
-                key: secret
+                name: {{ .Values.core.existingSecretSecret }}
+                key: {{ .Values.core.existingSecretSecretKey }}
+          {{- end }}
           - name: JOBSERVICE_SECRET
             valueFrom:
               secretKeyRef:
+                {{- if .Values.jobservice.existingSecret }}
+                name: {{ .Values.jobservice.existingSecret }}
+                key: {{ .Values.jobservice.existingSecretKey }}
+                {{- else }}
                 name: "{{ template "harbor.jobservice" . }}"
                 key: JOBSERVICE_SECRET
-         {{- if .Values.internalTLS.enabled }}
+                {{- end }}
+          {{- if .Values.existingSecretAdminPassword }}
+          - name: HARBOR_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.existingSecretAdminPassword }}
+                key: {{ .Values.existingSecretAdminPasswordKey }}
+          {{- end }}
+          {{- if (or .Values.database.internal.existingSecret .Values.database.external.existingSecret ) }}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                {{- if eq "internal" .Values.database.type }}
+                name: {{ .Values.database.internal.existingSecret }}
+                key: {{ .Values.database.internal.existingSecretKey }}
+                {{- else }}
+                name: {{ .Values.database.external.existingSecret }}
+                key: {{ .Values.database.external.existingSecretKey }}
+                {{- end }}
+          {{- end }}
+          {{- if .Values.registry.credentials.existingSecret }}
+          - name: REGISTRY_CREDENTIAL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.registry.credentials.existingSecret }}
+                key: {{ .Values.registry.credentials.existingSecretKey }}
+          {{- end }}
+          {{- if .Values.existingSecretXsrfKey }}
+          - name: CSRF_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.existingSecretXsrfKey }}
+                key: {{ .Values.existingSecretXsrfKeyKey }}
+          {{- end }}
+          {{- if .Values.internalTLS.enabled }}
           - name: INTERNAL_TLS_ENABLED
             value: "true"
           - name: INTERNAL_TLS_KEY_PATH
@@ -139,10 +179,17 @@ spec:
               path: app.conf
       - name: secret-key
         secret:
+          {{- if .Values.existingSecretSecretKey }}
+          secretName: {{ .Values.existingSecretSecretKey }}
+          items:
+            - key: {{ .Values.existingSecretSecretKeyKey }}
+              path: key
+          {{- else }}
           secretName: {{ template "harbor.core" . }}
           items:
             - key: secretKey
               path: key
+          {{- end }}
       - name: token-service-private-key
         secret:
           {{- if .Values.core.secretName }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -6,14 +6,27 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.existingSecretSecretKey }}
   secretKey: {{ .Values.secretKey | b64enc | quote }}
-  secret: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
-{{- if not .Values.core.secretName }}
+  {{- end }}
+  {{- if not .Values.core.existingSecretSecret }}
+  CORE_SECRET: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.core.secretName }}
   tls.crt: {{ .Files.Get "cert/tls.crt" | b64enc }}
   tls.key: {{ .Files.Get "cert/tls.key" | b64enc }}
-{{- end }}
+  {{- end }}
+  {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
+  {{- end }}
+  {{- if not (or .Values.database.internal.existingSecret .Values.database.external.existingSecret )}}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
+  {{- end }}
+  {{- if not .Values.registry.credentials.existingSecret }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.core.existingSecretXsrfKey }}
   CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
+  {{- end }}
+  {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}

--- a/templates/database/database-secret.yaml
+++ b/templates/database/database-secret.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.database.type "internal" -}}
+{{- if not .Values.database.internal.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,5 @@ metadata:
 type: Opaque
 data:
   POSTGRES_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
+{{- end -}}
 {{- end -}}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -92,14 +92,23 @@ spec:
         resources:
 {{ toYaml .Values.database.internal.resources | indent 10 }}
 {{- end }}
+        {{- if not .Values.database.internal.existingSecret }}
         envFrom:
           - secretRef:
               name: "{{ template "harbor.database" . }}"
+        {{- end }}
         env:
           # put the data into a sub directory to avoid the permission issue in k8s with restricted psp enabled
           # more detail refer to https://github.com/goharbor/harbor-helm/issues/756
           - name: PGDATA
             value: "/var/lib/postgresql/data/pgdata"
+          {{- if not .Values.database.internal.existingSecret }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.internal.existingSecret }}
+                key: {{ .Values.database.internal.existingSecretKey }}
+          {{- end }}
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -56,6 +56,28 @@ spec:
             name: "{{ template "harbor.exporter" . }}-env"
         - secretRef:
             name: "{{ template "harbor.exporter" . }}"
+        {{- if (or .Values.existingSecretAdminPassword (or .Values.database.internal.existingSecret .Values.database.external.existingSecret)) }}
+        env:
+        {{- if .Values.existingSecretAdminPassword }}
+        - name: HARBOR_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.existingSecretAdminPassword }}
+              key: {{ .Values.existingSecretAdminPasswordKey }}
+        {{- end }}
+        {{- if (or .Values.database.internal.existingSecret .Values.database.external.existingSecret ) }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq "internal" .Values.database.type }}
+              name: {{ .Values.database.internal.existingSecret }}
+              key: {{ .Values.database.internal.existingSecretKey }}
+              {{- else }}
+              name: {{ .Values.database.external.existingSecret }}
+              key: {{ .Values.database.external.existingSecretKey }}
+              {{- end }}
+        {{- end }}
+        {{- end }}
 {{- if .Values.exporter.resources }}
         resources:
 {{ toYaml .Values.exporter.resources | indent 10 }}

--- a/templates/exporter/exporter-secret.yaml
+++ b/templates/exporter/exporter-secret.yaml
@@ -11,6 +11,10 @@ data:
   tls.crt: {{ .Files.Get "cert/tls.crt" | b64enc }}
   tls.key: {{ .Files.Get "cert/tls.key" | b64enc }}
 {{- end }}
+  {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
+{{- end }}
+{{- if not (or .Values.database.internal.existingSecret .Values.database.external.existingSecret )}}
   HARBOR_DATABASE_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
+{{- end }}
 {{- end }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -76,6 +76,20 @@ spec:
               secretKeyRef:
                 name: {{ template "harbor.core" . }}
                 key: secret
+          {{- if .Values.jobservice.existingSecret }}
+          - name: JOBSERVICE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.jobservice.existingSecret }}
+                key: {{ .Values.jobservice.existingSecretKey }}
+          {{- end }}
+          {{- if .Values.registry.credentials.existingSecret }}
+          - name: REGISTRY_CREDENTIAL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.registry.credentials.existingSecret }}
+                key: {{ .Values.registry.credentials.existingSecretKey }}
+          {{- end }}
           {{- if .Values.internalTLS.enabled }}
           - name: INTERNAL_TLS_ENABLED
             value: "true"

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -6,6 +6,10 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.jobservice.existingSecret }}
   JOBSERVICE_SECRET: {{ .Values.jobservice.secret | default (randAlphaNum 16) | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.registry.credentials.existingSecret }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
+  {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -74,9 +74,25 @@ spec:
         envFrom:
         - secretRef:
             name: "{{ template "harbor.registry" . }}"
+        {{- if .Values.persistence.imageChartStorage.azure.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.azure.existingSecret }}
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.gcs.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.gcs.existingSecret }}
+        {{- end }}
         {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
         - secretRef:
             name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.swift.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.swift.existingSecret }}
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.oss.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.oss.existingSecret }}
         {{- end }}
         env:
         {{- if has "registry" .Values.proxy.components }}
@@ -86,6 +102,20 @@ spec:
           value: "{{ .Values.proxy.httpsProxy }}"
         - name: NO_PROXY
           value: "{{ template "harbor.noProxy" . }}"
+        {{- end }}
+        {{- if .Values.redis.external.existingSecret }}
+        - name: REGISTRY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.external.existingSecret }}
+              key: name: {{ .Values.redis.external.existingSecretPasswordKey }}
+        {{- end }}
+        {{- if .Values.registry.existingSecret }}
+        - name: REGISTRY_HTTP_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.registry.existingSecret }}
+              key: name: {{ .Values.registry.existingSecretKey }}
         {{- end }}
         {{- if .Values.internalTLS.enabled }}
         - name: INTERNAL_TLS_ENABLED
@@ -223,10 +253,17 @@ spec:
       volumes:
       - name: registry-htpasswd
         secret:
+          {{- if .Values.registry.credentials.existingSecret }}
+          secretName: {{ .Values.registry.credentials.existingSecret }}
+          items:
+            - key: {{ .Values.registry.credentials.existingSecretHtpasswdKey }}
+              path: passwd
+          {{- else }}
           secretName: {{ template "harbor.registry" . }}-htpasswd
           items:
             - key: REGISTRY_HTPASSWD
               path: passwd
+          {{- end }}
       - name: registry-config
         configMap:
           name: "{{ template "harbor.registry" . }}"

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -6,14 +6,22 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.registry.existingSecret }}
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (randAlphaNum 16) | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.redis.external.existingSecret }}
   REGISTRY_REDIS_PASSWORD: {{ (include "harbor.redis.password" .) | b64enc | quote }}
+  {{- end }}
   {{- $storage := .Values.persistence.imageChartStorage }}
   {{- $type := $storage.type }}
   {{- if eq $type "azure" }}
+  {{- if and (not $storage.azure.existingSecret) ($storage.azure.accountkey) }}
   REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $storage.azure.accountkey | b64enc | quote }}
+  {{- end }}
   {{- else if eq $type "gcs" }}
+  {{- if and (not $storage.gcs.existingSecret) ($storage.gcs.encodedkey) }}
   GCS_KEY_DATA: {{ $storage.gcs.encodedkey | quote }}
+  {{- end }}
   {{- else if eq $type "s3" }}
   {{- if and (not $storage.s3.existingSecret) ($storage.s3.accesskey) }}
   REGISTRY_STORAGE_S3_ACCESSKEY: {{ $storage.s3.accesskey | b64enc | quote }}
@@ -22,17 +30,22 @@ data:
   REGISTRY_STORAGE_S3_SECRETKEY: {{ $storage.s3.secretkey | b64enc | quote }}
   {{- end }}
   {{- else if eq $type "swift" }}
+  {{- if and (not $storage.swift.existingSecret) ($storage.swift.password) }}
   REGISTRY_STORAGE_SWIFT_PASSWORD: {{ $storage.swift.password | b64enc | quote }}
-  {{- if $storage.swift.secretkey }}
+  {{- end }}
+  {{- if and (not $storage.swift.existingSecret) $storage.swift.secretkey }}
   REGISTRY_STORAGE_SWIFT_SECRETKEY: {{ $storage.swift.secretkey | b64enc | quote }}
   {{- end }}
-  {{- if $storage.swift.accesskey }}
+  {{- if and (not $storage.swift.existingSecret) $storage.swift.accesskey }}
   REGISTRY_STORAGE_SWIFT_ACCESSKEY: {{ $storage.swift.accesskey | b64enc | quote }}
   {{- end }}
   {{- else if eq $type "oss" }}
+  {{- if and (not $storage.oss.existingSecret) ($storage.oss.accesskeysecret) }}
   REGISTRY_STORAGE_OSS_ACCESSKEYSECRET: {{ $storage.oss.accesskeysecret | b64enc | quote }}
+  {{ end }}
   {{- end }}
 ---
+{{- if not .Values.registry.credentials.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,3 +59,4 @@ data:
   {{- else }}
   REGISTRY_HTPASSWD: {{ htpasswd .Values.registry.credentials.username .Values.registry.credentials.password | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/templates/trivy/trivy-secret.yaml
+++ b/templates/trivy/trivy-secret.yaml
@@ -8,5 +8,7 @@ metadata:
 type: Opaque
 data:
   redisURL: {{ include "harbor.redis.urlForTrivy" . | b64enc }}
+  {{- not .Values.trivy.existingSecretGithubToken }}
   gitHubToken: {{  .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -72,8 +72,13 @@ spec:
             - name: "SCANNER_TRIVY_GITHUB_TOKEN"
               valueFrom:
                 secretKeyRef:
+                  {{- if not .Values.trivy.existingSecretGithubToken }}
+                  name: {{ .Values.trivy.existingSecretGithubToken }}
+                  key: {{ .Values.trivy.existingSecretGithubTokenKey }}
+                  {{- else }}
                   name: {{ template "harbor.trivy" . }}
                   key: gitHubToken
+                  {{- end }}
             - name: "SCANNER_TRIVY_SEVERITY"
               value: {{ .Values.trivy.severity | quote }}
             - name: "SCANNER_TRIVY_IGNORE_UNFIXED"

--- a/values.yaml
+++ b/values.yaml
@@ -294,6 +294,9 @@ persistence:
       rootdirectory: /storage
       #maxthreads: 100
     azure:
+      # Set an existing secret for Azure accountkey
+      # key in the secret should be AZURE_STORAGE_ACCESS_KEY
+      #existingSecret: ""
       accountname: accountname
       accountkey: base64encodedaccountkey
       container: containername
@@ -301,6 +304,9 @@ persistence:
     gcs:
       bucket: bucketname
       # The base64 encoded json file which contains the key
+      # Set an existing secret for Azure accountkey
+      # key in the secret should be GCS_KEY_DATA
+      #existingSecret: ""
       encodedkey: base64-encoded-json-key-file
       #rootdirectory: /gcs/object/name/prefix
       #chunksize: "5242880"
@@ -326,6 +332,13 @@ persistence:
       #multipartcopymaxconcurrency: 100
       #multipartcopythresholdsize: "33554432"
     swift:
+      # Set an existing secret for swift password
+      # key in the secret should be:
+      #  * OS_PASSWORD for password (chartmuseum)
+      #  * REGISTRY_STORAGE_SWIFT_PASSWORD for password (registry)
+      #  * REGISTRY_STORAGE_SWIFT_SECRETKEY for secretkey (registry)
+      #  * REGISTRY_STORAGE_SWIFT_ACCESSKEY for accesskey (registry)
+      #existingSecret: ""
       authurl: https://storage.myprovider.com/v3/auth
       username: username
       password: password
@@ -346,6 +359,9 @@ persistence:
       #tempurlcontainerkey: false
       #tempurlmethods:
     oss:
+      # Set an existing secret for oss accesskeysecret
+      # key in the secret should be ALIBABA_CLOUD_ACCESS_KEY_SECRET
+      #existingSecret: ""
       accesskeyid: accesskeyid
       accesskeysecret: accesskeysecret
       region: regionname
@@ -374,6 +390,10 @@ updateStrategy:
 logLevel: info
 
 # The initial password of Harbor admin. Change it from portal after launching Harbor
+# or give an existing secret for it
+# key in secret is given via (default to HARBOR_ADMIN_PASSWORD)
+#existingSecretAdminPassword:
+existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
 harborAdminPassword: "Harbor12345"
 
 # The name of the secret which contains key named "ca.crt". Setting this enables the
@@ -382,6 +402,11 @@ harborAdminPassword: "Harbor12345"
 caSecretName: ""
 
 # The secret key used for encryption. Must be a string of 16 chars.
+# Set an existing secret for secret-key
+# key in the secret is given via existingSecretSecretKey (default to secretKey)
+#existingSecretSecretKey: ""
+existingSecretSecretKeyKey: secretKey
+# If an existing secret is not specified, set secretKey above
 secretKey: "not-a-secure-key"
 
 # The proxy settings for updating trivy vulnerabilities from the Internet and replicating
@@ -478,8 +503,12 @@ core:
   ## Additional deployment annotations
   podAnnotations: {}
   # Secret is used when core server communicates with other components.
-  # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
+  # Set an existing secret for secret
+  # key in the secret is given via existingSecretSecretKey (default to CORE_SECRET)
+  #existingSecretSecret: ""
+  existingSecretSecretKey: CORE_SECRET
+  # If a secret key or an existing secret is not specified, Helm will generate one.
   secret: ""
   # Fill the name of a kubernetes secret if you want to use your own
   # TLS certificate and private key for token encryption/decryption.
@@ -488,6 +517,10 @@ core:
   # "tls.key" - the private key
   # The default key pair will be used if it isn't set
   secretName: ""
+  # Set an existing secret for XSRF key
+  # key in the secret is given via existingSecretXsrfKeyKey (default to CSRF_KEY)
+  #existingSecretXsrfKey: ""
+  existingSecretXsrfKeKey: CSRF_KEY
   # The XSRF key. Will be generated automatically if it isn't specified
   xsrfKey: ""
   ## The priority class to run the pod as
@@ -528,8 +561,12 @@ jobservice:
   ## Additional deployment annotations
   podAnnotations: {}
   # Secret is used when job service communicates with other components.
-  # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
+  # Set an existing secret for secret
+  # key in the secret is given via existingSecretKey (default to JOBSERVICE_SECRET)
+  #existingSecret: ""
+  existingSecretKey: JOBSERVICE_SECRET
+  # If a secret key or an existing secret is not specified, Helm will generate one.
   secret: ""
   ## The priority class to run the pod as
   priorityClassName:
@@ -568,16 +605,28 @@ registry:
   # Secret is used to secure the upload state from client
   # and registry storage backend.
   # See: https://github.com/docker/distribution/blob/master/docs/configuration.md#http
-  # If a secret key is not specified, Helm will generate one.
   # Must be a string of 16 chars.
+  # Set an existing secret for secret
+  # key in the secret is given via existingSecretKey (default to REGISTRY_HTTP_SECRET)
+  #existingSecret: ""
+  existingSecretKey: REGISTRY_HTTP_SECRET
+  # If a secret key or an existing secret is not specified, Helm will generate one.
+  # If a secret key is not specified, Helm will generate one.
   secret: ""
   # If true, the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL.
   relativeurls: false
   credentials:
     username: "harbor_registry_user"
+    # The user password for registry
+    # Set an existing secret for registry password
+    # key in the secret is given via existingSecretKey (default to REGISTRY_CREDENTIAL_PASSWORD)
+    #existingSecret: ""
+    existingSecretKey: REGISTRY_CREDENTIAL_PASSWORD
     password: "harbor_registry_password"
     # Login and password in htpasswd string format. Excludes `registry.credentials.username`  and `registry.credentials.password`. May come in handy when integrating with tools like argocd or flux. This allows the same line to be generated each time the template is rendered, instead of the `htpasswd` function from helm, which generates different lines each time because of the salt.
     # htpasswdString: $apr1$XLefHzeG$Xl4.s00sMSCCcMyJljSZb0 # example string
+    # If you use secret, you must also provide the "htpasswized" version in the secret as it wouldn't be possible to create other way
+    existingSecretHtpasswdKey: REGISTRY_CREDENTIAL_HTPASSWD
   middleware:
     enabled: false
     type: cloudFront
@@ -664,6 +713,10 @@ trivy:
   #
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+  # you can store it in an existing secret or set it directly
+  # key for secret should be set in  existingSecretGithubTokenKey (default to gitHubToken)
+  #existingSecretGithubToken:
+  existingSecretGithubTokenKey: gitHubToken
   gitHubToken: ""
   # skipUpdate the flag to disable Trivy DB downloads from GitHub
   #
@@ -759,6 +812,11 @@ database:
       repository: goharbor/harbor-db
       tag: dev
     # The initial superuser password for internal database
+    # Set an existing secret for db password
+    # key in the secret is given via existingSecretKey (default to POSTGRESQL_PASSWORD)
+    #existingSecret: ""
+    existingSecretKey: POSTGRESQL_PASSWORD
+    # If an existing secret is not specified, set secretKey password
     password: "changeit"
     # The size limit for Shared memory, pgSQL use it for shared_buffer
     # More details see:
@@ -788,6 +846,11 @@ database:
     host: "192.168.0.1"
     port: "5432"
     username: "user"
+    # The user password for database
+    # Set an existing secret for db password
+    # key in the secret is given via existingSecretKey (default to POSTGRESQL_PASSWORD)
+    #existingSecret: ""
+    existingSecretKey: POSTGRESQL_PASSWORD
     password: "password"
     coreDatabase: "registry"
     notaryServerDatabase: "notary_server"
@@ -845,6 +908,10 @@ redis:
     registryDatabaseIndex: "2"
     chartmuseumDatabaseIndex: "3"
     trivyAdapterIndex: "5"
+    # If a secret is provided, it will be used to configure redis password
+    existingSecret: ""
+    ## NOTE: ignored unless `auth.existingSecret` parameter is set
+    existingSecretPasswordKey: ""
     password: ""
   ## Additional deployment annotations
   podAnnotations: {}


### PR DESCRIPTION
There are a lot of sensitive datas (passwords, secrets, keys, ...) that needs to be given.
This patch allows to set them in a secret before installing and using the secret.

It's a new version of #1179 (I've redone it, I didn't reused it).

Current limitations:

* redis password with external may not work (as many components uses the "direct" url and it's not easy to fix that)
* notary has not been touched 
