### PR TITLE
Fix permissions for database

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -63,7 +63,7 @@ spec:
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chmod -R 700 /var/lib/postgresql/data/pgdata || true"]
+        args: ["-c", "chmod -R 700 /var/lib/postgresql/data/pgdata || true && chmod -R 700 /var/lib/postgresql/data/pgdata/pg* || true"]
 {{- if .Values.database.internal.initContainer.permissions.resources }}
         resources:
 {{ toYaml .Values.database.internal.initContainer.permissions.resources | indent 10 }}


### PR DESCRIPTION
When using Cstor Storage Class, in some cases restarting the database (Usually when cstor loses HA state), I often get the following error
```
postgres [ / ]$ /docker-entrypoint.sh 96 13 postgres
no need to upgrade postgres, launch it.
2022-07-31 08:09:54.073 UTC [17] FATAL:  data directory "/var/lib/postgresql/data/pgdata/pg13" has invalid permissions
2022-07-31 08:09:54.073 UTC [17] DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
postgres [ / ]$ ls -la /var/lib/postgresql/data/pgdata/pg13
total 132
drwxrws--- 19 postgres postgres  4096 Jul 27 00:33 .
drwxrws---  3 postgres postgres  4096 May 29 10:59 ..
-rwxrw----  1 postgres postgres     3 May 29 10:59 PG_VERSION
drwxrws---  8 postgres postgres  4096 May 29 10:59 base
drwxrws---  2 postgres postgres  4096 Jul 27 00:39 global
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_commit_ts
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_dynshmem
-rwxrw----  1 postgres postgres  4782 May 29 10:59 pg_hba.conf
-rwxrw----  1 postgres postgres  1636 May 29 10:59 pg_ident.conf
drwxrws---  4 postgres postgres  4096 Jul 31 03:48 pg_logical
drwxrws---  4 postgres postgres  4096 May 29 10:59 pg_multixact
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_notify
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_replslot
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_serial
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_snapshots
drwxrws---  2 postgres postgres  4096 Jul 16 05:09 pg_stat
drwxrws---  2 postgres postgres  4096 Jul 31 04:30 pg_stat_tmp
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_subtrans
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_tblspc
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_twophase
drwxrws---  3 postgres postgres  4096 Jul 31 03:48 pg_wal
drwxrws---  2 postgres postgres  4096 May 29 10:59 pg_xact
-rwxrw----  1 postgres postgres    88 May 29 10:59 postgresql.auto.conf
-rwxrw----  1 postgres postgres 27960 May 29 10:59 postgresql.conf
-rwxrw----  1 postgres postgres    99 Jul 27 00:33 postmaster.opts
-rw-rw----  1 postgres postgres   102 Jul 27 00:33 postmaster.pid
```

Looks like there's a misconfiguration here, and that can be fixed if I run a Pod manually, mount the volume and chmod 700 back into the directory

But I think it should be a part of data-permissions-ensurer in initContainers.

Note:
Kubernetes v1.23.9
Harbor v2.5.1
Cstor (OpenEBS - https://openebs.io/docs/user-guides/cstor) - 3.2.0
