### PR TITLE
Move the notary DB_URL strings into the notary-server secret

### DIFF
--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -17,4 +17,6 @@ data:
   {{- end }}
   server.json: {{ tpl (.Files.Get "conf/notary-server.json") . | b64enc }}
   signer.json: {{ tpl (.Files.Get "conf/notary-signer.json") . | b64enc }}
+  NOTARY_SERVER_DB_URL: {{ include "harbor.database.notaryServer" . | b64enc }}
+  NOTARY_SIGNER_DB_URL: {{ include "harbor.database.notarySigner" . | b64enc }}
 {{- end }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -61,7 +61,10 @@ spec:
         - name: MIGRATIONS_PATH
           value: migrations/server/postgresql
         - name: DB_URL
-          value: {{ template "harbor.database.notaryServer" . }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "harbor.notary-server" . }}
+              key: NOTARY_SERVER_DB_URL
         volumeMounts:
         - name: config
           mountPath: /etc/notary/server-config.postgres.json

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -60,7 +60,10 @@ spec:
         - name: MIGRATIONS_PATH
           value: migrations/signer/postgresql
         - name: DB_URL
-          value: {{ template "harbor.database.notarySigner" . }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "harbor.notary-server" . }}
+              key: NOTARY_SIGNER_DB_URL
         - name: NOTARY_SIGNER_DEFAULTALIAS
           value: defaultalias
         volumeMounts:


### PR DESCRIPTION
This is a fix for #1263 that moves the DB_URLs into a secret instead of having them in plain text in the resource definitions.

Signed-off-by: Curt Cunning <curt.cunning@outlook.com>