### PR TITLE
Harbor Registry -- Fix existing secret reference in deployment

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -243,7 +243,7 @@ spec:
           {{- if not .Values.registry.credentials.existingSecret }}
           secretName: {{ template "harbor.registry" . }}-htpasswd
           {{ else }}
-          secretName: .Values.registry.credentials.existingSecret
+          secretName: {{ .Values.registry.credentials.existingSecret }}
           {{- end }}
           items:
             - key: REGISTRY_HTPASSWD


### PR DESCRIPTION
Current code for specifying an existing secret for htpasswd in registry configuration doesn't work as expected due to missing `{{}}` to enable helm templating.

This change fixes this issue by adding `{{}}` to the respective parameter. 