### PR TITLE
Add certificate support for PSQL SSL connections

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 1.4.0-dev
+version: 1.4.1-dev
 appVersion: dev
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -135,6 +135,10 @@ app: "{{ template "harbor.name" . }}"
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.database.ssl-certs-secret" -}}
+  {{- printf "%s-ssl-certs-secret" (include "harbor.fullname" .) -}}
+{{- end -}}
+
 {{- define "harbor.database.notaryServer" -}}
 postgres://{{ template "harbor.database.username" . }}:{{ template "harbor.database.escapedRawPassword" . }}@{{ template "harbor.database.host" . }}:{{ template "harbor.database.port" . }}/{{ template "harbor.database.notaryServerDatabase" . }}?sslmode={{ template "harbor.database.sslmode" . }}
 {{- end -}}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -135,6 +135,10 @@ spec:
         - name: core-internal-certs
           mountPath: /etc/harbor/ssl/core
         {{- end }}
+        {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+        - name: psql-ssl-certs-secret
+          mountPath: /home/harbor/.postgresql
+        {{- end }}
         - name: psc
           mountPath: /etc/core/token
         {{- if .Values.caBundleSecretName }}
@@ -191,6 +195,20 @@ spec:
       - name: core-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.core.secretName" . }}
+      {{- end }}
+      {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+      - name: psql-ssl-certs-secret
+        secret:
+          defaultMode: 400
+          items:
+            - key: client.crt
+              path: postgresql.crt
+            - key: client.key
+              path: postgresql.key
+              mode: 384
+            - key: server.crt
+              path: root.crt
+          secretName: "{{ template "harbor.database.ssl-certs-secret" . }}"
       {{- end }}
       - name: psc
         emptyDir: {}

--- a/templates/database/database-external-ssl-certs.yaml
+++ b/templates/database/database-external-ssl-certs.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "harbor.database.ssl-certs-secret" . }}"
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+type: Opaque
+data:
+  client.crt: |-
+    {{ (required "The \"database.external.sslData.clientCertPath\" is required when using external DB with SSL!" .Values.database.external.sslData.clientCertPath) | .Files.Get | b64enc }}
+  client.key: |-
+    {{ (required "The \"database.external.sslData.clientKeyPath\" is required when using external DB with SSL!" .Values.database.external.sslData.clientKeyPath) | .Files.Get | b64enc }}
+  server.crt: |-
+    {{ (required "The \"database.external.sslData.serverCertPath\" is required when using external DB with SSL!" .Values.database.external.sslData.serverCertPath) | .Files.Get | b64enc }}
+{{- end -}}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -80,6 +80,10 @@ spec:
           # There are some metric data are collectd from harbor core.
           # When internal TLS is enabled, the Exporter need the CA file to collect these data.
         {{- end }}
+        {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+        - name: psql-ssl-certs-secret
+          mountPath: /home/harbor/.postgresql
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -88,6 +92,20 @@ spec:
       - name: core-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.core.secretName" . }}
+      {{- end }}
+      {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+      - name: psql-ssl-certs-secret
+        secret:
+          defaultMode: 400
+          items:
+            - key: client.crt
+              path: postgresql.crt
+            - key: client.key
+              path: postgresql.key
+              mode: 384
+            - key: server.crt
+              path: root.crt
+          secretName: "{{ template "harbor.database.ssl-certs-secret" . }}"
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -114,6 +114,10 @@ spec:
         - name: jobservice-internal-certs
           mountPath: /etc/harbor/ssl/jobservice
         {{- end }}
+        {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+        - name: psql-ssl-certs-secret
+          mountPath: /home/harbor/.postgresql
+        {{- end }}
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
@@ -139,6 +143,20 @@ spec:
       - name: jobservice-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.jobservice.secretName" . }}
+      {{- end }}
+      {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+      - name: psql-ssl-certs-secret
+        secret:
+          defaultMode: 400
+          items:
+            - key: client.crt
+              path: postgresql.crt
+            - key: client.key
+              path: postgresql.key
+              mode: 384
+            - key: server.crt
+              path: root.crt
+          secretName: "{{ template "harbor.database.ssl-certs-secret" . }}"
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -75,6 +75,10 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/ca.crt
           subPath: ca.crt
+        {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+        - name: psql-ssl-certs-secret
+          mountPath: /home/notary/.postgresql
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -93,6 +97,20 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+      - name: psql-ssl-certs-secret
+        secret:
+          defaultMode: 400
+          items:
+            - key: client.crt
+              path: postgresql.crt
+            - key: client.key
+              path: postgresql.key
+              mode: 384
+            - key: server.crt
+              path: root.crt
+          secretName: "{{ template "harbor.database.ssl-certs-secret" . }}"
+      {{- end }}
     {{- with .Values.notary.server.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -76,6 +76,10 @@ spec:
         - name: signer-certificate
           mountPath: /etc/ssl/notary/tls.key
           subPath: tls.key
+        {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+        - name: psql-ssl-certs-secret
+          mountPath: /home/notary/.postgresql
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -87,6 +91,20 @@ spec:
           {{- else }}
           secretName: {{ template "harbor.notary-server" . }}
           {{- end }}
+      {{- if and (eq .Values.database.type "external") (ne .Values.database.external.sslmode "disable") }}
+      - name: psql-ssl-certs-secret
+        secret:
+          defaultMode: 400
+          items:
+            - key: client.crt
+              path: postgresql.crt
+            - key: client.key
+              path: postgresql.key
+              mode: 384
+            - key: server.crt
+              path: root.crt
+          secretName: "{{ template "harbor.database.ssl-certs-secret" . }}"
+      {{- end }}
     {{- with .Values.notary.signer.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -810,7 +810,13 @@ database:
     # "verify-full" - Always SSL (verify that the certification presented by the
     # server was signed by a trusted CA and the server host name matches the one
     # in the certificate)
-    sslmode: "disable"
+    sslmode: disable
+    # client ssl data needed!
+    # sslmode: disable
+    # sslData:
+    #   clientCertPath: "ssl-data/client.crt"
+    #   clientKeyPath: "ssl-data/client.key"
+    #   serverCertPath: "ssl-data/server.crt"
   # The maximum number of connections in the idle connection pool per pod (core+exporter).
   # If it <=0, no idle connections are retained.
   maxIdleConns: 100


### PR DESCRIPTION
Provide client/server certificate data as a kubernetes secret

Note: notary-{server,signer} does not work due to fsGroup + permission restriction, s https://github.com/kubernetes/kubernetes/issues/57923

Signed-off-by: Damyan Yordanov <damyan.yordanov@sap.com>