### PR TITLE
Set default of updateStrategy matching to default accessMode

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -371,9 +371,10 @@ imagePullSecrets:
 
 # The update strategy for deployments with persistent volumes(jobservice, registry
 # and chartmuseum): "RollingUpdate" or "Recreate"
+# Set it as "RollingUpdate" when "RWM" for volumes is supported
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
-  type: RollingUpdate
+  type: Recreate
 
 # debug, info, warning, error or fatal
 logLevel: info


### PR DESCRIPTION
Because the default `accessMode` is `ReadWriteOnce` in the `value.yaml`, and since we know the combination with `RollingUpdate` [does not work](https://github.com/goharbor/harbor-helm/issues/408), I propose to change the default value.