### PR TITLE
Fix missing environment variable for registry container - Azure

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -100,6 +100,13 @@ spec:
         - name: INTERNAL_TLS_TRUST_CA_PATH
           value: /etc/harbor/ssl/registry/ca.crt
         {{- end }}
+        {{- if .Values.persistence.imageChartStorage.azure.existingSecret }}
+        - name: REGISTRY_STORAGE_AZURE_ACCOUNTKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.persistence.imageChartStorage.azure.existingSecret }}
+              key: AZURE_STORAGE_ACCESS_KEY
+        {{- end }}
         ports:
         - containerPort: {{ template "harbor.registry.containerPort" . }}
         - containerPort: 5001


### PR DESCRIPTION
Fixes: #1309 

Add missing environment variable to registry container - only happens when using existingSecret for Azure imageChartStorage