### PR TITLE
Add an ability to disable PVC for scandata

### DIFF
--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -129,7 +129,7 @@ spec:
         emptyDir: {}
         {{- end }}
       - name: job-scandata-exports
-        {{- if and .Values.persistence.enabled }}
+        {{- if and .Values.persistence.enabled .Values.persistence.persistScanData }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.persistentVolumeClaim.jobservice.scanDataExports.existingClaim | default (include "harbor.jobserviceScandata" .) }}
         {{- else }}

--- a/templates/jobservice/jobservice-pvc-scandata.yaml
+++ b/templates/jobservice/jobservice-pvc-scandata.yaml
@@ -1,5 +1,5 @@
 {{- $scandataExports := .Values.persistence.persistentVolumeClaim.jobservice.scanDataExports -}}
-{{- if and .Values.persistence.enabled (not $scandataExports.existingClaim) }}
+{{- if and .Values.persistence.enabled .Values.persistence.persistScanData (not $scandataExports.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -204,6 +204,7 @@ ipFamily:
 # "swift" or "oss". Set it in the "imageChartStorage" section
 persistence:
   enabled: true
+  persistScanData: false
   # Setting it to "keep" to avoid removing PVCs during a helm delete
   # operation. Leaving it empty will delete PVCs after the chart deleted
   # (this does not apply for PVCs that are created for internal database
@@ -362,7 +363,7 @@ persistence:
       #secure: true
       #chunksize: 10M
       #rootdirectory: rootdirectory
-
+  
 imagePullPolicy: IfNotPresent
 
 # Use this set to assign a list of default pullSecrets


### PR DESCRIPTION
To deal with https://github.com/goharbor/harbor-helm/issues/1320, we should add ability to completely disable creation and usage of ScanData PVC.