### PR TITLE
allow using existing secret for notary database URL

### DIFF
--- a/templates/notary/notary-secret.yaml
+++ b/templates/notary/notary-secret.yaml
@@ -17,6 +17,8 @@ data:
   {{- end }}
   server.json: {{ tpl (.Files.Get "conf/notary-server.json") . | b64enc }}
   signer.json: {{ tpl (.Files.Get "conf/notary-signer.json") . | b64enc }}
+  {{- if not .Values.database.external.existingSecret }}
   NOTARY_SERVER_DB_URL: {{ include "harbor.database.notaryServer" . | b64enc }}
   NOTARY_SIGNER_DB_URL: {{ include "harbor.database.notarySigner" . | b64enc }}
+  {{- end }}
 {{- end }}

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -60,11 +60,24 @@ spec:
         env:
         - name: MIGRATIONS_PATH
           value: migrations/server/postgresql
+{{- if not .Values.database.external.existingSecret }}
         - name: DB_URL
           valueFrom:
             secretKeyRef:
               name: {{ template "harbor.notary-server" . }}
               key: NOTARY_SERVER_DB_URL
+{{- else }}
+        - name: DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret }}
+              key: NOTARY_SERVER_DB_URL
+        - name: NOTARY_SERVER_STORAGE_DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret }}
+              key: NOTARY_SERVER_DB_URL
+{{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/notary/server-config.postgres.json

--- a/templates/notary/notary-signer.yaml
+++ b/templates/notary/notary-signer.yaml
@@ -59,11 +59,24 @@ spec:
         env:
         - name: MIGRATIONS_PATH
           value: migrations/signer/postgresql
+{{- if not .Values.database.external.existingSecret }}
         - name: DB_URL
           valueFrom:
             secretKeyRef:
               name: {{ template "harbor.notary-server" . }}
               key: NOTARY_SIGNER_DB_URL
+{{- else }}
+        - name: DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret }}
+              key: NOTARY_SIGNER_DB_URL
+        - name: NOTARY_SIGNER_STORAGE_DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret }}
+              key: NOTARY_SIGNER_DB_URL
+{{- end }}
         - name: NOTARY_SIGNER_DEFAULTALIAS
           value: defaultalias
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -772,7 +772,10 @@ database:
     coreDatabase: "registry"
     notaryServerDatabase: "notary_server"
     notarySignerDatabase: "notary_signer"
-    # if using existing secret, the key must be "password"
+    # if using existing secret, the keys must be the following:
+    # "password" - for harbor-core, containing the database password
+    # "NOTARY_SERVER_DB_URL" - for notary-server, containing the database connection URL, e.g.: postgres://user:S3cr3t@host:5432/notary-server-database
+    # "NOTARY_SIGNER_DB_URL" - for notary-signer, containing the database connection URL, e.g.: postgres://user:S3cr3t@host:5432/notary-signer-database
     existingSecret: ""
     # "disable" - No SSL
     # "require" - Always SSL (skip verification)


### PR DESCRIPTION
- allow using existing secret for setting the database URL for notary when using an external database
- solves #1358
- did not touch the server.json and signer.json templates as the incorrect database URL in those will be overwritten
- added the `NOTARY_SERVER_STORAGE_DB_URL` and `NOTARY_SIGNER_STORAGE_DB_URL` environment variables to the notary-server and notary-signer containers respectively which use the existing secret to inject the database URL into the containers
  - these variables follow the naming scheme to overwrite configuration values (see https://github.com/notaryproject/notary/blob/master/docs/running_a_service.md#overriding-configuration-file-parameters-using-environment-variables)