### PR TITLE
prefer dual stack when using nodePort

### DIFF
--- a/templates/nginx/service.yaml
+++ b/templates/nginx/service.yaml
@@ -34,6 +34,7 @@ spec:
 {{ include "harbor.labels" . | indent 4 }}
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: http
       port: {{ $nodePort.ports.http.port }}


### PR DESCRIPTION
So that it will listen on both v4 and v6 externally.