### PR TITLE
feat: add configmap checksum annotation for portal

### DIFF
--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -23,6 +23,7 @@ spec:
 {{- else if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "manual") }}
         checksum/tls: {{ include (print $.Template.BasePath "/portal/tls.yaml") . | sha256sum }}
 {{- end }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/portal/configmap.yaml") . | sha256sum }}  
 {{- if .Values.portal.podAnnotations }}
 {{ toYaml .Values.portal.podAnnotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
There is a scenario from helm upgrade (for harbor upgrade/patch etc) with values changes that the configmap is not updated. This request is to add a support in portal/deployment to aware the configmap changes.