### PR TITLE
feat:Add external proxy option

### DIFF
--- a/templates/nginx/configmap-http.yaml
+++ b/templates/nginx/configmap-http.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.expose.type "ingress") (not .Values.expose.tls.enabled) }}
+{{- if and (ne .Values.expose.type "ingress") (ne .Values.expose.type "external") (not .Values.expose.tls.enabled) }}
 {{- $scheme := (include "harbor.component.scheme" .) -}}
 apiVersion: v1
 kind: ConfigMap

--- a/templates/nginx/configmap-https.yaml
+++ b/templates/nginx/configmap-https.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.expose.type "ingress") .Values.expose.tls.enabled }}
+{{- if and (ne .Values.expose.type "ingress") (ne .Values.expose.type "external") .Values.expose.tls.enabled }}
 {{- $scheme := (include "harbor.component.scheme" .) -}}
 apiVersion: v1
 kind: ConfigMap

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.expose.type "ingress" }}
+{{- if and (ne .Values.expose.type "ingress") (ne .Values.expose.type "external") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 expose:
-  # Set how to expose the service. Set the type as "ingress", "clusterIP", "nodePort" or "loadBalancer"
+  # Set how to expose the service. Set the type as "ingress", "clusterIP", "nodePort", "loadBalancer" or "external" if not using nginx
   # and fill the information in the corresponding section
   type: ingress
   tls:
@@ -396,7 +396,7 @@ enableMigrateHelmHook: false
 # contains a base64 encoded CA Certificate named `ca.crt`.
 # uaaSecretName:
 
-# If service exposed via "ingress", the Nginx will not be used
+# If service exposed via "ingress" or "external", the Nginx will not be used
 nginx:
   image:
     repository: goharbor/nginx-photon


### PR DESCRIPTION
The Harbor architecture describes a Proxy layer, but the Helm chart doesn't allow for that layer to be provided by anything other than nginx, with either an nginx object being created if the expose type is "ingress", or nginx itself being deployed if set to anything else.

I would like to extend the functionality to be able to 'bring my own proxy', in my case I want to use Contour with HTTPproxy objects. Rather than implement support for this in Harbor, it is easier simply to implement and expose option of 'external' where the chart can assume the proxy deployment is handled elsewhere. In this case no nginx deployment or object creation is triggered by the chart.