### PR TITLE
Fix the exporter's containerPort

### DIFF
--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -83,7 +83,7 @@ spec:
 {{- toYaml . | nindent 10 }}
 {{- end }}
         ports:
-        - containerPort: {{ template "harbor.core.containerPort" . }}
+        - containerPort: {{ .Values.metrics.exporter.port }}
         volumeMounts:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}


### PR DESCRIPTION
The exporter's `containerPort` should use `.Values.metrics.exporter.port`, not `harbor.core.containerPort`.