### PR TITLE
Fix the registry's containerPort

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -115,7 +115,7 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ template "harbor.registry.containerPort" . }}
-        - containerPort: 5001
+        - containerPort: {{ ternary .Values.metrics.registry.port 5001 .Values.metrics.enabled }}
         volumeMounts:
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}


### PR DESCRIPTION
The registry's `containerPort` should use `.Values.metrics.registry.port` instead of `5001` if `.Values.metrics.enabled` is `true`.