### PR TITLE
Fix the nginx's containerPort

### DIFF
--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -79,8 +79,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: 8080
+        {{- if .Values.expose.tls.enabled }}
         - containerPort: 8443
-        - containerPort: 4443
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
It is better to limit the nginx's `containerPort` and `port` to only those that are enabled.

`8443` is valid only if `.Values.expose.tls.enabled` is `true`.
`4443` is valid only if `.Values.expose.tls.enabled` and `.Values.notary.enabled` are both `true`.