### PR TITLE
fix: add github-ghcr to the list of PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -46,7 +46,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry,jfrog-artifactory"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry,github-ghcr,jfrog-artifactory"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"


### PR DESCRIPTION
Fixes: #1489 
