### PR TITLE
Fix #1127 - remove capabilities check for prometheus

### DIFF
--- a/templates/metrics/metrics-svcmon.yaml
+++ b/templates/metrics/metrics-svcmon.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Removes the use of `.Capabilities` from the prometheus serviceMonitor. This allows things that utilize `helm template` or other similar tools to work.

Fixes #1127 