### PR TITLE
disable external redis using username

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -148,7 +148,7 @@ app: "{{ template "harbor.name" . }}"
 {{- define "harbor.redis.url" -}}
   {{- with .Values.redis }}
     {{- $path := ternary "" (printf "/%s" (include "harbor.redis.masterSet" $)) (not (include "harbor.redis.masterSet" $)) }}
-    {{- $cred := ternary (printf "%s:%s@" (.external.username | urlquery) (.external.password | urlquery)) "" (and (eq .type "external" ) (not (not .external.password))) }}
+    {{- $cred := ternary (printf ":%s@" (.external.password | urlquery)) "" (and (eq .type "external" ) (not (not .external.password))) }}
     {{- printf "%s://%s%s%s" (include "harbor.redis.scheme" $) $cred (include "harbor.redis.addr" $) $path -}}
   {{- end }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -817,8 +817,6 @@ redis:
     jobserviceDatabaseIndex: "1"
     registryDatabaseIndex: "2"
     trivyAdapterIndex: "5"
-    # username field can be an empty string and it will be authenticated against the default user
-    username: ""
     password: ""
     # If using existingSecret, the key must be REDIS_PASSWORD
     existingSecret: ""


### PR DESCRIPTION
- introduced by: https://github.com/goharbor/harbor-helm/pull/1143/
- affect version: v2.8.0, v2.8.1, v2.8.2 (harbor helm v1.12.0, v1.12.1, v1.12.2)
- impact: distribution performance

**Expected behavior and actual behavior:**
upstream distribution do not support username-password auth mode
using `external_reids.username` would cause distribution redis connection failure , which would not affect image push/pull but only have an impact on distribution performance, could see error log in the registry container.
```
time="2023-07-05T06:29:53.894080917Z" level=error msg="redis: error connecting: WRONGPASS invalid username-password pair or user is disabled." go.version=go1.20.4 instance.id=ea5a081f-84d5-4d63-8618-70f2078871be redis.connect.duration=124.519µs service=registry version=v2.8.2.m
time="2023-07-05T06:29:53.894240222Z" level=error msg="redis: error connecting: WRONGPASS invalid username-password pair or user is disabled." go.version=go1.20.4 instance.id=ea5a081f-84d5-4d63-8618-70f2078871be redis.connect.duration=116.94µs service=registry version=v2.8.2.m
```

**Steps to reproduce the problem:**
- configure external redis with both username and password
```
redis:
  type: external
  external:
      addr: "myhost:6379"
      username:   virginia
      password: mypassword123
```
- install harbor
- push/pull image into harbor 

**Versions:**
Please specify the versions of following systems.

- harbor version: v2.8.0/v2.8.1 / v2.8.2

**Additional context:**

Note: distribution (until v2.8.2) only support auth by password
- https://pkg.go.dev/github.com/distribution/distribution/v3/configuration
- https://github.com/distribution/distribution/blob/7c354a4b40feeea21d7eeae4de91c8ff7951e672/registry/handlers/app.go#L530
