### PR TITLE
Core service doesn't use redis.external.existingSecret

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -123,6 +123,13 @@ spec:
                 name: {{ .Values.database.external.existingSecret }}
                 key: password
           {{- end }}
+          {{- if .Values.redis.external.existingSecret }}
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.redis.external.existingSecret }}
+                key: REDIS_PASSWORD
+          {{- end }}
           {{- if .Values.registry.credentials.existingSecret }}
           - name: REGISTRY_CREDENTIAL_PASSWORD
             valueFrom:

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -124,7 +124,7 @@ spec:
                 key: password
           {{- end }}
           {{- if .Values.redis.external.existingSecret }}
-          - name: REDIS_PASSWORD
+          - name: CORE_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.redis.external.existingSecret }}


### PR DESCRIPTION
Hi!
I faced the missconfiguration:
1. You have redis.external.existingSecret defined
2. You trying to deploy harbor
3. You get issue `2023-07-07T15:49:40Z [ERROR] [/lib/cache/cache.go:123]: failed to ping redis+sentinel://path/to/extRedis, retry after 10s : NOAUTH Authentication required.`

root cause: core service doesn't take password from existing secret defined in `redis.external.existingSecret` for redis. 
It worked for me when I defined password in `redis.external.password` only.

Here it is defined correctly for registry service:
https://github.com/goharbor/harbor-helm/blob/c8853808bd657359ed8fba454c45fd2b98862c3c/templates/registry/registry-dpl.yaml#L221-L225