### PR TITLE
Add registryctl env secretRef for S3 existingSecret

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -188,6 +188,10 @@ spec:
             name: "{{ template "harbor.registry" . }}"
         - secretRef:
             name: "{{ template "harbor.registryCtl" . }}"
+        {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
         env:
         - name: CORE_SECRET
           valueFrom:


### PR DESCRIPTION
If `persistence.imageChartStorage.s3.existingSecret` has been set, ensure the there is an envFrom secretRef for the `registryctl` container. This is already applied to the `registry` container.

Without this change when an existing S3 secret is used, garbage collection on an S3 bucket fails to successfully delete any blobs because the `registryctl` container has no valid S3 Auth available to it. 

The result of this issue is an ever growing S3 bucket that Harbor does not track because it has removed knowledge of the manifests/blobs during GC.