### PR TITLE
Fix: Avoid recreating random secrets

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -528,22 +528,26 @@ app: "{{ template "harbor.name" . }}"
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.core" .) ) -}}
 {{- if $secret -}}
 {{/* Reusing existing secret data */}}
-secret: {{ index $secret "data" "secret" }}
 CSRF_KEY: {{ index $secret "data" "CSRF_KEY" }}
+HARBOR_ADMIN_PASSWORD: {{ index $secret "data" "HARBOR_ADMIN_PASSWORD" }}
+POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
+REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
+secret: {{ index $secret "data" "secret" }}
+secretKey: {{ index $secret "data" "secretKey" }}
 tls.key: {{ index $secret "data" "tls.key" }}
 tls.crt: {{ index $secret "data" "tls.crt" }}
 {{- else -}}
 {{/* 
   Generate new data
 */}}
+{{- if not .Values.existingSecretSecretKey }}
+secretKey: {{ .Values.secretKey | b64enc | quote }}
+{{- end }}
 secret: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
-CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
+{{- if not .Values.core.secretName }}
 {{- $ca := genCA "harbor-token-ca" 365 }}
 tls.key: {{ .Values.core.tokenKey | default $ca.Key | b64enc | quote }}
 tls.crt: {{ .Values.core.tokenCert | default $ca.Cert | b64enc | quote }}
-{{- end }}
-{{- if not .Values.existingSecretSecretKey }}
-secretKey: {{ .Values.secretKey | b64enc | quote }}
 {{- end }}
 {{- if not .Values.existingSecretAdminPassword }}
 HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
@@ -554,9 +558,11 @@ POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
 {{- if not .Values.registry.credentials.existingSecret }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
 {{- end }}
+CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
 {{- if .Values.core.configureUserSettings }}
 CONFIG_OVERWRITE_JSON: {{ .Values.core.configureUserSettings | b64enc | quote }}
 {{- end }}
+{{- end -}}
 {{- template "harbor.traceJaegerPassword" . }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -529,7 +529,9 @@ app: "{{ template "harbor.name" . }}"
 {{- if $secret -}}
 {{/* Reusing existing secret data */}}
 CSRF_KEY: {{ index $secret "data" "CSRF_KEY" }}
+{{- if not .Values.existingSecretAdminPassword }}
 HARBOR_ADMIN_PASSWORD: {{ index $secret "data" "HARBOR_ADMIN_PASSWORD" }}
+{{- end }}
 POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
 secret: {{ index $secret "data" "secret" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -539,7 +539,9 @@ POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
 {{- end }}
 secret: {{ index $secret "data" "secret" }}
+{{- if not .Values.existingSecretSecretKey }}
 secretKey: {{ index $secret "data" "secretKey" }}
+{{- end }}
 {{- if not .Values.core.secretName }}
 tls.key: {{ index $secret "data" "tls.key" }}
 tls.crt: {{ index $secret "data" "tls.crt" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -534,8 +534,10 @@ POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
 secret: {{ index $secret "data" "secret" }}
 secretKey: {{ index $secret "data" "secretKey" }}
+{{- if not .Values.core.secretName }}
 tls.key: {{ index $secret "data" "tls.key" }}
 tls.crt: {{ index $secret "data" "tls.crt" }}
+{{- end }}
 {{- else -}}
 {{/* 
   Generate new data

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -528,6 +528,7 @@ app: "{{ template "harbor.name" . }}"
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.core" .) ) -}}
 {{- if $secret -}}
 {{/* Reusing existing secret data */}}
+CONFIG_OVERWRITE_JSON: {{ index $secret "data" "CONFIG_OVERWRITE_JSON" }}
 CSRF_KEY: {{ index $secret "data" "CSRF_KEY" }}
 {{- if not .Values.existingSecretAdminPassword }}
 HARBOR_ADMIN_PASSWORD: {{ index $secret "data" "HARBOR_ADMIN_PASSWORD" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -535,7 +535,9 @@ HARBOR_ADMIN_PASSWORD: {{ index $secret "data" "HARBOR_ADMIN_PASSWORD" }}
 {{- if not .Values.database.external.existingSecret }}
 POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
 {{- end }}
+{{- if not .Values.registry.credentials.existingSecret }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
+{{- end }}
 secret: {{ index $secret "data" "secret" }}
 secretKey: {{ index $secret "data" "secretKey" }}
 {{- if not .Values.core.secretName }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -640,3 +640,21 @@ REGISTRY_HTPASSWD: {{ htpasswd .Values.registry.credentials.username .Values.reg
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* Harbor Ingress Secret generator */}}
+{{- define "harbor.ingress.secret" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.ingress" .) ) -}}
+{{- if $secret -}}
+{{/* Reusing existing secret data */}}
+tls.crt: {{ index $secret "data" "tls.crt" }}
+tls.key: {{ index $secret "data" "tls.key" }}
+ca.crt: {{ index $secret "data" "ca.crt" }}
+{{- else -}}
+{{/* Generate new data */}}
+{{- $ca := genCA "harbor-ca" 365 }}
+{{- $cert := genSignedCert .Values.expose.ingress.hosts.core nil (list .Values.expose.ingress.hosts.core) 365 $ca }}
+tls.crt: {{ $cert.Cert | b64enc | quote }}
+tls.key: {{ $cert.Key | b64enc | quote }}
+ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -532,7 +532,9 @@ CSRF_KEY: {{ index $secret "data" "CSRF_KEY" }}
 {{- if not .Values.existingSecretAdminPassword }}
 HARBOR_ADMIN_PASSWORD: {{ index $secret "data" "HARBOR_ADMIN_PASSWORD" }}
 {{- end }}
+{{- if not .Values.database.external.existingSecret }}
 POSTGRESQL_PASSWORD: {{ index $secret "data" "POSTGRESQL_PASSWORD" }}
+{{- end }}
 REGISTRY_CREDENTIAL_PASSWORD: {{ index $secret "data" "REGISTRY_CREDENTIAL_PASSWORD" }}
 secret: {{ index $secret "data" "secret" }}
 secretKey: {{ index $secret "data" "secretKey" }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -6,26 +6,4 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  {{- if not .Values.existingSecretSecretKey }}
-  secretKey: {{ .Values.secretKey | b64enc | quote }}
-  {{- end }}
-  secret: {{ .Values.core.secret | default (randAlphaNum 16) | b64enc | quote }}
-  {{- if not .Values.core.secretName }}
-  {{- $ca := genCA "harbor-token-ca" 365 }}
-  tls.key: {{ .Values.core.tokenKey | default $ca.Key | b64enc | quote }}
-  tls.crt: {{ .Values.core.tokenCert | default $ca.Cert | b64enc | quote }}
-  {{- end }}
-  {{- if not .Values.existingSecretAdminPassword }}
-  HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
-  {{- end }}
-  {{- if not .Values.database.external.existingSecret }}
-  POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
-  {{- end }}
-  {{- if not .Values.registry.credentials.existingSecret }}
-  REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
-  {{- end }}
-  CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}
-{{- if .Values.core.configureUserSettings }}
-  CONFIG_OVERWRITE_JSON: {{ .Values.core.configureUserSettings | b64enc | quote }}
-{{- end }}
-  {{- template "harbor.traceJaegerPassword" . }}
+  {{- ( include "harbor.core.secret" . ) | indent 2 -}}

--- a/templates/ingress/secret.yaml
+++ b/templates/ingress/secret.yaml
@@ -1,6 +1,4 @@
 {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
-{{- $ca := genCA "harbor-ca" 365 }}
-{{- $cert := genSignedCert .Values.expose.ingress.hosts.core nil (list .Values.expose.ingress.hosts.core) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +7,5 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- ( include "harbor.ingress.secret" . ) | indent 2 -}}
 {{- end }}

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -6,8 +6,5 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  JOBSERVICE_SECRET: {{ .Values.jobservice.secret | default (randAlphaNum 16) | b64enc | quote }}
-  {{- if not .Values.registry.credentials.existingSecret }}
-  REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
-  {{- end }}
-  {{- template "harbor.traceJaegerPassword" . }}
+  {{- ( include "harbor.jobservice.secret" . ) | indent 2 -}}
+  

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -6,34 +6,8 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (randAlphaNum 16) | b64enc | quote }}
-  {{- if not .Values.redis.external.existingSecret }}
-  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
-  {{- end }}
-  {{- $storage := .Values.persistence.imageChartStorage }}
-  {{- $type := $storage.type }}
-  {{- if and (eq $type "azure") (not $storage.azure.existingSecret) }}
-  REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $storage.azure.accountkey | b64enc | quote }}
-  {{- else if and (and (eq $type "gcs") (not $storage.gcs.existingSecret)) (not $storage.gcs.useWorkloadIdentity) }}
-  GCS_KEY_DATA: {{ $storage.gcs.encodedkey | quote }}
-  {{- else if eq $type "s3" }}
-  {{- if and (not $storage.s3.existingSecret) ($storage.s3.accesskey) }}
-  REGISTRY_STORAGE_S3_ACCESSKEY: {{ $storage.s3.accesskey | b64enc | quote }}
-  {{- end }}
-  {{- if and (not $storage.s3.existingSecret) ($storage.s3.secretkey) }}
-  REGISTRY_STORAGE_S3_SECRETKEY: {{ $storage.s3.secretkey | b64enc | quote }}
-  {{- end }}
-  {{- else if eq $type "swift" }}
-  REGISTRY_STORAGE_SWIFT_PASSWORD: {{ $storage.swift.password | b64enc | quote }}
-  {{- if $storage.swift.secretkey }}
-  REGISTRY_STORAGE_SWIFT_SECRETKEY: {{ $storage.swift.secretkey | b64enc | quote }}
-  {{- end }}
-  {{- if $storage.swift.accesskey }}
-  REGISTRY_STORAGE_SWIFT_ACCESSKEY: {{ $storage.swift.accesskey | b64enc | quote }}
-  {{- end }}
-  {{- else if eq $type "oss" }}
-  REGISTRY_STORAGE_OSS_ACCESSKEYSECRET: {{ $storage.oss.accesskeysecret | b64enc | quote }}
-  {{- end }}
+  {{- ( include "harbor.registry.secret" . ) | indent 2 -}}
+
 {{- if not .Values.registry.credentials.existingSecret }}
 ---
 apiVersion: v1
@@ -44,9 +18,5 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
 data:
-  {{- if .Values.registry.credentials.htpasswdString }}
-  REGISTRY_HTPASSWD: {{ .Values.registry.credentials.htpasswdString | b64enc | quote }}
-  {{- else }}
-  REGISTRY_HTPASSWD: {{ htpasswd .Values.registry.credentials.username .Values.registry.credentials.password | b64enc | quote }}
-  {{- end }}
+  {{- ( include "harbor.registry.secret-htpasswd" . ) | indent 2 -}}
 {{- end }}


### PR DESCRIPTION
Avoid recreating secrets with dynamic/random content on every helm update. This causes the `core`, `registry` and `jobservice` services to be redeployed in each update.

Related to https://cloud-native.slack.com/archives/CC1E09J6S/p1689925408303219

Close #1549 