### PR TITLE
[Feature] Harbor branding

### DIFF
--- a/templates/portal/configmap.yaml
+++ b/templates/portal/configmap.yaml
@@ -65,3 +65,8 @@ data:
             }
         }
     }
+{{- if .Values.portal.branding.enabled }}
+  setting.json: >-
+{{ .Values.portal.branding.config | toJson | indent 4 }}
+{{- end }}
+

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -121,14 +121,14 @@ spec:
                 name: {{ .Values.portal.branding.imageMounts.logo.configMapName | quote }}
                 items:
                   - key: {{ .Values.portal.branding.imageMounts.logo.filename | quote }}
-                    path: {{ printf "/%s" .Values.portal.branding.imageMounts.logo.filename | quote }}
+                    path: {{ .Values.portal.branding.imageMounts.logo.filename | quote }}
             {{- end }}
             {{- if not (or (empty .Values.portal.branding.imageMounts.loginBgImg.configMapName) (empty .Values.portal.branding.imageMounts.loginBgImg.filename)) }}
             - configMap:
                 name: {{ .Values.portal.branding.imageMounts.loginBgImg.configMapName | quote }}
                 items:
                   - key: {{ .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
-                    path: {{ printf "/%s" .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
+                    path: {{ .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
             {{- end }}
       {{- end }}
     {{- with .Values.portal.nodeSelector }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -26,7 +26,7 @@ spec:
 {{- else if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "manual") }}
         checksum/tls: {{ include (print $.Template.BasePath "/portal/tls.yaml") . | sha256sum }}
 {{- end }}
-        checksum/configmap: {{ include (print $.Template.BasePath "/portal/configmap.yaml") . | sha256sum }}  
+        checksum/configmap: {{ include (print $.Template.BasePath "/portal/configmap.yaml") . | sha256sum }}
 {{- if .Values.portal.podAnnotations }}
 {{ toYaml .Values.portal.podAnnotations | indent 8 }}
 {{- end }}
@@ -88,6 +88,21 @@ spec:
         - name: portal-internal-certs
           mountPath: /etc/harbor/ssl/portal
         {{- end }}
+        {{- if .Values.portal.branding.enabled }}
+        - name: portal-config
+          mountPath: /usr/share/nginx/html/setting.json
+          subPath: setting.json
+        {{- end }}
+        {{- if not (or (empty .Values.portal.branding.imageMounts.logo.configMapName) (empty .Values.portal.branding.imageMounts.logo.filename)) }}
+        - name: portal-branding
+          mountPath: {{ printf "/usr/share/nginx/html/images/%s" .Values.portal.branding.imageMounts.logo.filename | quote }}
+          subPath: {{ .Values.portal.branding.imageMounts.logo.filename | quote }}
+        {{- end }}
+        {{- if not (or (empty .Values.portal.branding.imageMounts.loginBgImg.configMapName) (empty .Values.portal.branding.imageMounts.loginBgImg.filename)) }}
+        - name: portal-branding
+          mountPath: {{ printf "/usr/share/nginx/html/images/%s" .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
+          subPath: {{ .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
+        {{- end }}
       volumes:
       - name: portal-config
         configMap:
@@ -96,6 +111,25 @@ spec:
       - name: portal-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.portal.secretName" . }}
+      {{- end }}
+      {{- if .Values.portal.branding.enabled}}
+      - name: portal-branding
+        projected:
+          sources:
+            {{- if not (or (empty .Values.portal.branding.imageMounts.logo.configMapName) (empty .Values.portal.branding.imageMounts.logo.filename)) }}
+            - configMap:
+                name: {{ .Values.portal.branding.imageMounts.logo.configMapName | quote }}
+                items:
+                  - key: {{ .Values.portal.branding.imageMounts.logo.filename | quote }}
+                    path: {{ printf "/%s" .Values.portal.branding.imageMounts.logo.filename | quote }}
+            {{- end }}
+            {{- if not (or (empty .Values.portal.branding.imageMounts.loginBgImg.configMapName) (empty .Values.portal.branding.imageMounts.loginBgImg.filename)) }}
+            - configMap:
+                name: {{ .Values.portal.branding.imageMounts.loginBgImg.configMapName | quote }}
+                items:
+                  - key: {{ .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
+                    path: {{ printf "/%s" .Values.portal.branding.imageMounts.loginBgImg.filename | quote }}
+            {{- end }}
       {{- end }}
     {{- with .Values.portal.nodeSelector }}
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -434,6 +434,26 @@ portal:
   podAnnotations: {}
   ## Additional deployment labels
   podLabels: {}
+  ## Branding configuration
+  branding:
+    enabled: false
+    imageMounts:
+      logo:
+        configMapName: ""
+        filename: ""
+      loginBgImg:
+        configMapName: ""
+        filename: ""
+    config:
+      headerBgColor:
+        darkMode: ""
+        lightMode: ""
+      loginBgImg: ""
+      loginTitle: ""
+      product:
+        name: ""
+        logo": ""
+        introduction: ""
   ## The priority class to run the pod as
   priorityClassName:
 


### PR DESCRIPTION
This PR enables Harbor branding via the helm chart by mounting `setting.json` file inside portal deployment.
Additionally, it can mount image files from `ConfigMaps` to be used as logo and/or login background (since configmaps can store small binary files)