### PR TITLE
[Cherry-pick] Add registryctl env secretRef for S3 existingSecret

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -172,6 +172,10 @@ spec:
             name: "{{ template "harbor.registry" . }}"
         - secretRef:
             name: "{{ template "harbor.registryCtl" . }}"
+        {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
+        - secretRef:
+            name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
+        {{- end }}
         env:
         - name: CORE_SECRET
           valueFrom:


### PR DESCRIPTION
If s3.existingSecret has been set, ensure the there is an envFrom secretRef for the registryctl container.

Cherry-pick of this PR: https://github.com/goharbor/harbor-helm/pull/1545