### PR TITLE
停止trivy更新DB，需要把环境变量TRIVY_SKIP_DB_UPDATE也置为true

### DIFF
--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -93,6 +93,8 @@ spec:
               value: {{ .Values.trivy.ignoreUnfixed | default false | quote }}
             - name: "SCANNER_TRIVY_SKIP_UPDATE"
               value: {{ .Values.trivy.skipUpdate | default false | quote }}
+            - name: "SCANNER_TRIVY_SKIP_DB_UPDATE"
+              value: {{ .Values.trivy.skipUpdate | default false | quote }}
             - name: "SCANNER_TRIVY_OFFLINE_SCAN"
               value: {{ .Values.trivy.offlineScan | default false | quote }}
             - name: "SCANNER_TRIVY_SECURITY_CHECKS"


### PR DESCRIPTION
停止trivy更新DB，需要把环境变量TRIVY_SKIP_DB_UPDATE也置为true