### PR TITLE
fix: avoid decoding plain text password when database secret exists

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -98,7 +98,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.database" .) -}}
     {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "POSTGRES_PASSWORD") -}}
-      {{- .Values.database.internal.password | default (index $existingSecret.data "POSTGRES_PASSWORD") | b64dec -}}
+      {{- .Values.database.internal.password | default (index $existingSecret.data "POSTGRES_PASSWORD" | b64dec) -}}
     {{- else -}}
       {{- .Values.database.internal.password -}}
     {{- end -}}


### PR DESCRIPTION
Fixes #1674