### PR TITLE
add multiple domains

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 1.4.0-dev
+version: 1.4.0-dev1
 appVersion: dev
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -60,10 +60,13 @@ spec:
   - secretName: {{ template "harbor.tlsCoreSecretForIngress" . }}
     {{- if $ingress.hosts.core }}
     hosts:
-    - {{ $ingress.hosts.core }}
+    {{- range $host:= $ingress.hosts.core }}
+    - {{ $host }}
+    {{- end }}
     {{- end }}
   {{- end }}
   rules:
+{{- range $host:= $ingress.hosts.core }}
   - http:
       paths:
 {{- if semverCompare "<1.19-0" (include "harbor.ingress.kubeVersion" .) }}
@@ -135,8 +138,6 @@ spec:
             port:
               number: {{ template "harbor.portal.servicePort" . }}
 {{- end }}
-    {{- if $ingress.hosts.core }}
-    host: {{ $ingress.hosts.core }}
-    {{- end }}
-
+    host: {{ $host }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,8 @@ expose:
       secretName: ""
   ingress:
     hosts:
-      core: core.harbor.domain
+      core:
+        - core.harbor.domain
     # set to the type of ingress controller if it has specific requirements.
     # leave as `default` for most ingress controllers.
     # set to `gce` if using the GCE ingress controller


### PR DESCRIPTION
Harbor may use multiple domains for registry and helm charts

```
https://registry.<fqdn>
https://helm-charts.<fqdn>
```

and we needed patching ingress for operate in this state