### PR TITLE
Add certmanager as internalTLS source

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -446,6 +446,19 @@ app: "{{ template "harbor.name" . }}"
   {{- printf "%s://%s:%s" (include "harbor.component.scheme" .) (include "harbor.trivy" .) (include "harbor.trivy.servicePort" .) -}}
 {{- end -}}
 
+{{/* FOR CERTMANAGER RESOURCES */}}
+{{- define "harbor.internalTLS.selfIssuer" -}}
+  {{- printf "%s-internal-self-issuer" (include "harbor.fullname" .) -}}
+{{- end -}}
+
+{{- define "harbor.internalTLS.caIssuer" -}}
+  {{- printf "%s-internal-ca-issuer" (include "harbor.fullname" .) -}}
+{{- end -}}
+
+{{- define "harbor.internalTLS.ca.secretName" -}}
+  {{- printf "%s-internal-tls-ca" (include "harbor.fullname" .) -}}
+{{- end -}}
+
 {{- define "harbor.internalTLS.core.secretName" -}}
   {{- if eq .Values.internalTLS.certSource "secret" -}}
     {{- .Values.internalTLS.core.secretName -}}

--- a/templates/internal/certmanager/internal-ca-issuer.yaml
+++ b/templates/internal/certmanager/internal-ca-issuer.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+spec:
+  ca:
+    secretName: {{ (include "harbor.internalTLS.ca.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-ca.yaml
+++ b/templates/internal/certmanager/internal-ca.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.ca.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.selfIssuer" .) }}
+  isCA: true
+  commonName: {{ (include "harbor.internalTLS.ca.secretName" .) }}
+  secretName: {{ (include "harbor.internalTLS.ca.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-core-tls.yaml
+++ b/templates/internal/certmanager/internal-core-tls.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.core.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+  dnsNames:
+    - {{ (include "harbor.core" .) }}
+  secretName: {{ (include "harbor.internalTLS.core.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-jobservice-tls.yaml
+++ b/templates/internal/certmanager/internal-jobservice-tls.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.jobservice.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+  dnsNames:
+    - {{ (include "harbor.jobservice" .) }}
+  secretName: {{ (include "harbor.internalTLS.jobservice.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-portal-tls.yaml
+++ b/templates/internal/certmanager/internal-portal-tls.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.portal.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+  dnsNames:
+    - {{ (include "harbor.portal" .) }}
+  secretName: {{ (include "harbor.internalTLS.portal.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-registry-tls.yaml
+++ b/templates/internal/certmanager/internal-registry-tls.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.registry.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+  dnsNames:
+    - {{ (include "harbor.registry" .) }}
+  secretName: {{ (include "harbor.internalTLS.registry.secretName" .) }}
+{{- end -}}

--- a/templates/internal/certmanager/internal-self-issuer.yaml
+++ b/templates/internal/certmanager/internal-self-issuer.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ (include "harbor.internalTLS.selfIssuer" .) }}
+spec:
+  selfSigned: {}
+{{- end -}}

--- a/templates/internal/certmanager/internal-trivy-tls.yaml
+++ b/templates/internal/certmanager/internal-trivy-tls.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "certmanager") .Values.trivy.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ (include "harbor.internalTLS.trivy.secretName" .) }}
+spec:
+  duration: 8760h0m0s
+  issuerRef:
+    kind: Issuer
+    name: {{ (include "harbor.internalTLS.caIssuer" .) }}
+  dnsNames:
+    - {{ (include "harbor.trivy" .) }}
+  secretName: {{ (include "harbor.internalTLS.trivy.secretName" .) }}
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -276,6 +276,7 @@ internalTLS:
   # 1) "auto" will generate cert automatically
   # 2) "manual" need provide cert file manually in following value
   # 3) "secret" internal certificates from secret
+  # 4) "certmanager" will generate cert automatically using certmanager
   certSource: "auto"
   # The content of trust ca, only available when `certSource` is "manual"
   trustCa: ""


### PR DESCRIPTION
Implements the same exact certificates for internalTLS as "auto" option, but using certmanager. 
This solved a couple problems:
1. Certificates are automatically renewed
2. Certificates are no longer regenerated each time on `helm upgrade`

Will test it on a working instance