### PR TITLE
remove the data migrator

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -41,26 +41,6 @@ spec:
       automountServiceAccountToken: {{ .Values.database.internal.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
       initContainers:
-      # as we change the data directory to a sub folder to support psp, the init container here
-      # is used to migrate the existing data. See https://github.com/goharbor/harbor-helm/issues/756
-      # for more detail.
-      # we may remove it after several releases
-      - name: "data-migrator"
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- if not (empty .Values.containerSecurityContext) }}
-        securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
-        {{- end }}
-        command: ["/bin/sh"]
-        args: ["-c", "[ -e /var/lib/postgresql/data/postgresql.conf ] && [ ! -d /var/lib/postgresql/data/pgdata ] && mkdir -m 0700 /var/lib/postgresql/data/pgdata && mv /var/lib/postgresql/data/* /var/lib/postgresql/data/pgdata/ || true"]
-{{- if .Values.database.internal.initContainer.migrator.resources }}
-        resources:
-{{ toYaml .Values.database.internal.initContainer.migrator.resources | indent 10 }}
-{{- end }}
-        volumeMounts:
-          - name: database-data
-            mountPath: /var/lib/postgresql/data
-            subPath: {{ $database.subPath }}
       # with "fsGroup" set, each time a volume is mounted, Kubernetes must recursively chown() and chmod() all the files and directories inside the volume
       # this causes the postgresql reports the "data directory /var/lib/postgresql/data/pgdata has group or world access" issue when using some CSIs e.g. Ceph
       # use this init container to correct the permission


### PR DESCRIPTION
Our upgrade support policy follows the n-2 principle, meaning upgrades must be at least to version 1.12.0 or higher. Starting from this version or later, the data path has been transitioned to pgdata, eliminating the need for additional steps to check and migrate.