### PR TITLE
Add support for HPA and Keda autoscaling

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -7,7 +7,9 @@ metadata:
     component: core
     app.kubernetes.io/component: core
 spec:
+  {{- if eq .Values.core.autoscaling.enabled .Values.core.keda.enabled }}
   replicas: {{ .Values.core.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.core.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/templates/core/core-hpa.yaml
+++ b/templates/core/core-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.core.autoscaling.enabled (not .Values.core.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.core.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: core
+  name: {{ template "harbor.core" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.core" . }}
+  minReplicas: {{ .Values.core.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.core.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.core.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.core.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.core.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.core.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/core/core-keda.yaml
+++ b/templates/core/core-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.core.keda.enabled (not .Values.core.autoscaling.enabled) -}}
+apiVersion: {{ .Values.core.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.core.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: core
+  name: {{ template "harbor.core" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.core.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.core" . }}
+{{- else if eq .Values.core.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.core" . }}
+{{- end }}
+  pollingInterval: {{ .Values.core.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.core.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.core.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.core.keda.maxReplicas }}
+{{- with .Values.core.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.core.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.core.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.core.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.core.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.core.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -8,7 +8,9 @@ metadata:
     component: exporter
     app.kubernetes.io/component: exporter
 spec:
+    {{- if eq .Values.exporter.autoscaling.enabled .Values.exporter.keda.enabled }}
   replicas: {{ .Values.exporter.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.exporter.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/templates/exporter/exporter-hpa.yaml
+++ b/templates/exporter/exporter-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.exporter.autoscaling.enabled (not .Values.exporter.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.exporter.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: exporter
+  name: {{ template "harbor.exporter" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.exporter" . }}
+  minReplicas: {{ .Values.exporter.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.exporter.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.exporter.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.exporter.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.exporter.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.exporter.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/exporter/exporter-keda.yaml
+++ b/templates/exporter/exporter-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.exporter.keda.enabled (not .Values.exporter.autoscaling.enabled) -}}
+apiVersion: {{ .Values.exporter.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.exporter.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: exporter
+  name: {{ template "harbor.exporter" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.exporter.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.exporter" . }}
+{{- else if eq .Values.exporter.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.exporter" . }}
+{{- end }}
+  pollingInterval: {{ .Values.exporter.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.exporter.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.exporter.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.exporter.keda.maxReplicas }}
+{{- with .Values.exporter.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.exporter.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.exporter.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.exporter.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.exporter.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.exporter.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -7,7 +7,9 @@ metadata:
     component: jobservice
     app.kubernetes.io/component: jobservice
 spec:
+  {{- if eq .Values.jobservice.autoscaling.enabled .Values.jobservice.keda.enabled }}
   replicas: {{ .Values.jobservice.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.jobservice.revisionHistoryLimit }}
   strategy:
     type: {{ .Values.updateStrategy.type }}

--- a/templates/jobservice/jobservice-hpa.yaml
+++ b/templates/jobservice/jobservice-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.jobservice.autoscaling.enabled (not .Values.jobservice.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.jobservice.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: jobservice
+  name: {{ template "harbor.jobservice" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.jobservice" . }}
+  minReplicas: {{ .Values.jobservice.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.jobservice.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.jobservice.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.jobservice.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.jobservice.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.jobservice.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/jobservice/jobservice-keda.yaml
+++ b/templates/jobservice/jobservice-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.jobservice.keda.enabled (not .Values.jobservice.autoscaling.enabled) -}}
+apiVersion: {{ .Values.jobservice.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.jobservice.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: jobservice
+  name: {{ template "harbor.jobservice" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.jobservice.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.jobservice" . }}
+{{- else if eq .Values.jobservice.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.jobservice" . }}
+{{- end }}
+  pollingInterval: {{ .Values.jobservice.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.jobservice.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.jobservice.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.jobservice.keda.maxReplicas }}
+{{- with .Values.jobservice.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.jobservice.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.jobservice.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.jobservice.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.jobservice.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.jobservice.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     component: nginx
     app.kubernetes.io/component: nginx
 spec:
+  {{- if eq .Values.nginx.autoscaling.enabled .Values.nginx.keda.enabled }}
   replicas: {{ .Values.nginx.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.nginx.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/templates/nginx/nginx-hpa.yaml
+++ b/templates/nginx/nginx-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.nginx.autoscaling.enabled (not .Values.nginx.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.nginx.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+  name: {{ template "harbor.nginx" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.nginx" . }}
+  minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.nginx.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.nginx.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/nginx/nginx-keda.yaml
+++ b/templates/nginx/nginx-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.nginx.keda.enabled (not .Values.nginx.autoscaling.enabled) -}}
+apiVersion: {{ .Values.nginx.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.nginx.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+  name: {{ template "harbor.nginx" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.nginx.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.nginx" . }}
+{{- else if eq .Values.nginx.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.nginx" . }}
+{{- end }}
+  pollingInterval: {{ .Values.nginx.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.nginx.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.nginx.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.nginx.keda.maxReplicas }}
+{{- with .Values.nginx.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.nginx.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.nginx.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.nginx.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.nginx.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.nginx.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     component: portal
     app.kubernetes.io/component: portal
 spec:
+  {{- if eq .Values.portal.autoscaling.enabled .Values.portal.keda.enabled }}
   replicas: {{ .Values.portal.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.portal.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/templates/portal/portal-hpa.yaml
+++ b/templates/portal/portal-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.portal.autoscaling.enabled (not .Values.portal.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.portal.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: portal
+  name: {{ template "harbor.portal" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.portal" . }}
+  minReplicas: {{ .Values.portal.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.portal.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.portal.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.portal.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.portal.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.portal.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/portal/portal-keda.yaml
+++ b/templates/portal/portal-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.portal.keda.enabled (not .Values.portal.autoscaling.enabled) -}}
+apiVersion: {{ .Values.portal.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.portal.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: portal
+  name: {{ template "harbor.portal" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.portal.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.portal" . }}
+{{- else if eq .Values.portal.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.portal" . }}
+{{- end }}
+  pollingInterval: {{ .Values.portal.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.portal.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.portal.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.portal.keda.maxReplicas }}
+{{- with .Values.portal.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.portal.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.portal.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.portal.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.portal.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.portal.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -9,7 +9,9 @@ metadata:
     component: registry
     app.kubernetes.io/component: registry
 spec:
+  {{- if eq .Values.registry.autoscaling.enabled .Values.registry.keda.enabled }}
   replicas: {{ .Values.registry.replicas }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.registry.revisionHistoryLimit }}
   strategy:
     type: {{ .Values.updateStrategy.type }}

--- a/templates/registry/registry-hpa.yaml
+++ b/templates/registry/registry-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.registry.autoscaling.enabled (not .Values.registry.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.registry.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registry
+  name: {{ template "harbor.registry" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "harbor.registry" . }}
+  minReplicas: {{ .Values.registry.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.registry.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.registry.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.registry.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.registry.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.registry.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/registry/registry-keda.yaml
+++ b/templates/registry/registry-keda.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.registry.keda.enabled (not .Values.registry.autoscaling.enabled) -}}
+apiVersion: {{ .Values.registry.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.registry.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registry
+  name: {{ template "harbor.registry" . }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.registry.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ template "harbor.registry" . }}
+{{- else if eq .Values.registry.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ template "harbor.registry" . }}
+{{- end }}
+  pollingInterval: {{ .Values.registry.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.registry.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.registry.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.registry.keda.maxReplicas }}
+{{- with .Values.registry.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.registry.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.registry.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.registry.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.registry.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.registry.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/trivy/trivy-hpa.yaml
+++ b/templates/trivy/trivy-hpa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.trivy.autoscaling.enabled (not .Values.trivy.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  {{- with .Values.trivy.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+  name: {{ template "harbor.trivy" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ template "harbor.trivy" . }}
+  minReplicas: {{ .Values.trivy.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.trivy.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.trivy.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.trivy.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.trivy.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.trivy.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/trivy/trivy-keda.yaml
+++ b/templates/trivy/trivy-keda.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.trivy.keda.enabled (not .Values.trivy.autoscaling.enabled) (eq .Values.trivy.keda.apiVersion "keda.sh/v1alpha1") -}}
+apiVersion: {{ .Values.trivy.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  {{- with .Values.trivy.autoscaling.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "harbor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+  name: {{ template "harbor.trivy" . }}
+spec:
+  scaleTargetRef:
+    name: {{ template "harbor.trivy" . }}
+  pollingInterval: {{ .Values.trivy.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.trivy.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.trivy.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.trivy.keda.maxReplicas }}
+{{- with .Values.trivy.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.trivy.keda.maxReplicas }}
+{{- end }}
+  triggers:
+{{- with .Values.trivy.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.trivy.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.trivy.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.trivy.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -9,7 +9,9 @@ metadata:
     component: trivy
     app.kubernetes.io/component: trivy
 spec:
+    {{- if eq .Values.trivy.autoscaling.enabled .Values.trivy.keda.enabled }}
   replicas: {{ .Values.trivy.replicas }}
+  {{- end }}
   serviceName: {{  template "harbor.trivy" . }}
   selector:
     matchLabels:

--- a/values.yaml
+++ b/values.yaml
@@ -511,6 +511,80 @@ nginx:
   ## The priority class to run the pod as
   priorityClassName:
 
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+
 portal:
   image:
     repository: goharbor/harbor-portal
@@ -543,6 +617,80 @@ portal:
   serviceAnnotations: {}
   ## The priority class to run the pod as
   priorityClassName:
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
 
 core:
   image:
@@ -608,21 +756,95 @@ core:
   # tokenKey and tokenCert must BOTH be set or BOTH unset.
   # The tokenKey value is formatted as a multiline string containing a PEM-encoded RSA key, indented one more than tokenKey on the following line.
   tokenKey: |
-  # If tokenKey is set, the value of tokenCert must be set as a PEM-encoded certificate signed by tokenKey, and supplied as a multiline string, indented one more than tokenCert on the following line.
-  tokenCert: |
-  # The XSRF key. Will be generated automatically if it isn't specified
-  xsrfKey: ""
-  # If using existingSecret, the key is defined by core.existingXsrfSecretKey
-  existingXsrfSecret: ""
-  # If using existingSecret, the key
-  existingXsrfSecretKey: CSRF_KEY
-  # The time duration for async update artifact pull_time and repository
-  # pull_count, the unit is second. Will be 10 seconds if it isn't set.
-  # eg. artifactPullAsyncFlushDuration: 10
-  artifactPullAsyncFlushDuration:
-  gdpr:
-    deleteUser: false
-    auditLogsCompliant: false
+    # If tokenKey is set, the value of tokenCert must be set as a PEM-encoded certificate signed by tokenKey, and supplied as a multiline string, indented one more than tokenCert on the following line.
+    tokenCert: |
+    # The XSRF key. Will be generated automatically if it isn't specified
+    xsrfKey: ""
+    # If using existingSecret, the key is defined by core.existingXsrfSecretKey
+    existingXsrfSecret: ""
+    # If using existingSecret, the key
+    existingXsrfSecretKey: CSRF_KEY
+    # The time duration for async update artifact pull_time and repository
+    # pull_count, the unit is second. Will be 10 seconds if it isn't set.
+    # eg. artifactPullAsyncFlushDuration: 10
+    artifactPullAsyncFlushDuration:
+    gdpr:
+      deleteUser: false
+      auditLogsCompliant: false
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
 
 jobservice:
   image:
@@ -678,6 +900,80 @@ jobservice:
   existingSecret: ""
   # Key within the existing secret for the job service secret
   existingSecretKey: JOBSERVICE_SECRET
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
 
 registry:
   registry:
@@ -758,6 +1054,80 @@ registry:
     # the interval of the purge operations
     interval: 24h
     dryrun: false
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
 
 trivy:
   # enabled the flag to enable Trivy scanner
@@ -844,6 +1214,80 @@ trivy:
   securityCheck: "vuln"
   # The duration to wait for scan completion
   timeout: 5m0s
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
 
 database:
   # if external database is used, set "type" to "external"
@@ -1007,3 +1451,77 @@ exporter:
   #   whenUnsatisfiable: DoNotSchedule
   cacheDuration: 23
   cacheCleanInterval: 14400
+
+  # Mutually exclusive with keda autoscaling
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  # - type: Pods
+  #   pods:
+  #     metric:
+  #       name: nginx_ingress_controller_nginx_process_requests_total
+  #     target:
+  #       type: AverageValue
+  #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+    # - type: prometheus
+    #   metadata:
+    #     serverAddress: http://<prometheus-host>:9090
+    #     metricName: http_requests_total
+    #     threshold: '100'
+    #     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60


### PR DESCRIPTION
We are adding support for autoscale deployments with [Horizontal Pod Autoscaling (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) and [Keda](https://keda.sh/).

This change is backward compatible since it adds new functionalities. With the default values the new settings have no effect.

Out of scope:

- **database**: `replicas` is hardcoded to 1
- **redis**: `replicas` is hardcoded to 1

close #1068 
