### PR TITLE
feat: manage the fsGroupChangePolicy configuration using the values.yaml 

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -44,7 +44,9 @@ spec:
       securityContext:
         runAsUser: 10000
         fsGroup: 10000
-        fsGroupChangePolicy: OnRootMismatch
+        {{- if not (empty .Values.registry.fsGroupChangePolicy) }}
+        fsGroupChangePolicy: {{ .Values.registry.fsGroupChangePolicy }}
+        {{- end }}
 {{- if .Values.registry.serviceAccountName }}
       serviceAccountName: {{ .Values.registry.serviceAccountName }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -611,6 +611,7 @@ registry:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  fsGroupChangePolicy: "OnRootMismatch"
   # Spread Pods across failure-domains like regions, availability zones or nodes
   topologySpreadConstraints: []
   # - maxSkew: 1


### PR DESCRIPTION
Move the fsGroupChangePolicy value of the registry to the values.yaml, so that different field values can be configured for it.