### PR TITLE
Fix ArgoCD integration by adding `metadata.namespace` to all templates

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "harbor.core" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.core" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: core

--- a/templates/core/core-pre-upgrade-job.yaml
+++ b/templates/core/core-pre-upgrade-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: migration-job
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: migrator

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "harbor.core" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/core/core-svc.yaml
+++ b/templates/core/core-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "harbor.core" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 {{- with .Values.core.serviceAnnotations }}

--- a/templates/core/core-tls.yaml
+++ b/templates/core/core-tls.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.core.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/database/database-secret.yaml
+++ b/templates/database/database-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.database" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "harbor.database" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: database

--- a/templates/database/database-svc.yaml
+++ b/templates/database/database-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.database" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/exporter/exporter-cm-env.yaml
+++ b/templates/exporter/exporter-cm-env.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.exporter" . }}-env"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.exporter" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: exporter

--- a/templates/exporter/exporter-secret.yaml
+++ b/templates/exporter/exporter-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "harbor.exporter" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/exporter/exporter-svc.yaml
+++ b/templates/exporter/exporter-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.exporter" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -35,6 +35,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ template "harbor.ingress" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 {{- if $ingress.labels }}

--- a/templates/ingress/secret.yaml
+++ b/templates/ingress/secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.ingress" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/internal/auto-tls.yaml
+++ b/templates/internal/auto-tls.yaml
@@ -14,6 +14,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.core.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -27,6 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.jobservice.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -40,6 +42,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.registry.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -53,6 +56,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.portal.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -69,6 +73,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.trivy.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/jobservice/jobservice-cm-env.yaml
+++ b/templates/jobservice/jobservice-cm-env.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.jobservice" . }}-env"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/jobservice/jobservice-cm.yaml
+++ b/templates/jobservice/jobservice-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.jobservice" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.jobservice" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: jobservice

--- a/templates/jobservice/jobservice-pvc.yaml
+++ b/templates/jobservice/jobservice-pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "harbor.jobservice" . }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
   {{- range $key, $value := $jobLog.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.jobservice" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/jobservice/jobservice-svc.yaml
+++ b/templates/jobservice/jobservice-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.jobservice" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/jobservice/jobservice-tls.yaml
+++ b/templates/jobservice/jobservice-tls.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.jobservice.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/metrics/metrics-svcmon.yaml
+++ b/templates/metrics/metrics-svcmon.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "harbor.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "harbor.labels" . | nindent 4 }}
 {{- if .Values.metrics.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}

--- a/templates/nginx/configmap-http.yaml
+++ b/templates/nginx/configmap-http.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "harbor.nginx" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/nginx/configmap-https.yaml
+++ b/templates/nginx/configmap-https.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "harbor.nginx" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "harbor.nginx" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: nginx

--- a/templates/nginx/secret.yaml
+++ b/templates/nginx/secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "harbor.nginx" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/nginx/service.yaml
+++ b/templates/nginx/service.yaml
@@ -5,6 +5,7 @@ metadata:
 {{- if eq .Values.expose.type "clusterIP" }}
 {{- $clusterIP := .Values.expose.clusterIP }}
   name: {{ $clusterIP.name }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 {{- if .Values.expose.clusterIP.labels }}

--- a/templates/portal/configmap.yaml
+++ b/templates/portal/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.portal" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.portal" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: portal

--- a/templates/portal/service.yaml
+++ b/templates/portal/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.portal" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 {{- with .Values.portal.serviceAnnotations }}

--- a/templates/portal/tls.yaml
+++ b/templates/portal/tls.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.portal.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/redis/service.yaml
+++ b/templates/redis/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "harbor.redis" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "harbor.redis" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: redis

--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.registry" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.registry" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: registry

--- a/templates/registry/registry-pvc.yaml
+++ b/templates/registry/registry-pvc.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "harbor.registry" . }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
   {{- range $key, $value := $registry.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.registry" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque
@@ -43,6 +44,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.registry" . }}-htpasswd"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/registry/registry-svc.yaml
+++ b/templates/registry/registry-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.registry" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/registry/registry-tls.yaml
+++ b/templates/registry/registry-tls.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.registry.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/templates/registry/registryctl-cm.yaml
+++ b/templates/registry/registryctl-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "harbor.registryCtl" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 data:

--- a/templates/registry/registryctl-secret.yaml
+++ b/templates/registry/registryctl-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.registryCtl" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/trivy/trivy-secret.yaml
+++ b/templates/trivy/trivy-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "harbor.trivy" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: Opaque

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "harbor.trivy" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
     component: trivy

--- a/templates/trivy/trivy-svc.yaml
+++ b/templates/trivy/trivy-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "harbor.trivy" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 spec:

--- a/templates/trivy/trivy-tls.yaml
+++ b/templates/trivy/trivy-tls.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "harbor.internalTLS.trivy.secretName" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls


### PR DESCRIPTION
When deploying kubernetes manifests via [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), errors are thrown because the `metadata.namespace` is missing.

This is also just a common practice seen across the vast majority of helm charts.

(worth noting that a similar MR was made a few years back: https://github.com/goharbor/harbor-helm/pull/587)