### PR TITLE
Only create harbor secrets if values require any of their contents

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -94,6 +94,7 @@ spec:
             name: "{{ template "harbor.core" . }}"
         - secretRef:
             name: "{{ template "harbor.core" . }}"
+            optional: true
         env:
           - name: CORE_SECRET
             valueFrom:

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -1,4 +1,25 @@
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.core" .) }}
+
+
+{{- $createSecret := not .Values.core.existingSecret}}
+{{- if not .Values.existingSecretSecretKey }}
+{{- $createSecret = true }}
+{{- else if not .Values.core.secretName }}
+{{- $createSecret = true }}
+{{- else if not .Values.existingSecretAdminPassword }}
+{{- $createSecret = true }}
+{{- else if not .Values.database.external.existingSecret }}
+{{- $createSecret = true }}
+{{- else if not .Values.registry.credentials.existingSecret }}
+{{- $createSecret = true }}
+{{- else if not .Values.core.existingXsrfSecret }}
+{{- $createSecret = true }}
+{{- else if .Values.core.configureUserSettings }}
+{{- $createSecret = true }}
+{{- else if and .Values.trace.enabled (eq .Values.trace.provider "jaeger") }}
+{{- $createSecret = true }}
+{{- end }}
+{{- if $createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -34,3 +55,4 @@ data:
   CONFIG_OVERWRITE_JSON: {{ .Values.core.configureUserSettings | b64enc | quote }}
 {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}
+{{- end }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -76,8 +76,10 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.exporter" . }}-env"
+{{- if or (not .Values.existingSecretAdminPassword) (not .Values.database.external.existingSecret) }}
         - secretRef:
             name: "{{ template "harbor.exporter" . }}"
+{{- end }}
         env:
         {{- if .Values.database.external.existingSecret }}
         - name: HARBOR_DATABASE_PASSWORD

--- a/templates/exporter/exporter-secret.yaml
+++ b/templates/exporter/exporter-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.metrics.enabled}}
+{{- if or (not .Values.existingSecretAdminPassword) (not .Values.database.external.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,5 +13,6 @@ data:
 {{- end }}
 {{- if not .Values.database.external.existingSecret }}
   HARBOR_DATABASE_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -130,6 +130,7 @@ spec:
             name: "{{ template "harbor.jobservice" . }}-env"
         - secretRef:
             name: "{{ template "harbor.jobservice" . }}"
+            optional: true
         ports:
         - containerPort: {{ template "harbor.jobservice.containerPort" . }}
         volumeMounts:

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -1,4 +1,5 @@
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.jobservice" .) }}
+{{- if or (or (not .Values.jobservice.existingSecret) (not .Values.registry.credentials.existingSecret)) (and .Values.trace.enabled (eq .Values.trace.provider "jaeger"))  }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
   {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}
+{{- end }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -99,6 +99,7 @@ spec:
         envFrom:
         - secretRef:
             name: "{{ template "harbor.registry" . }}"
+            optional: true
         {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}
         - secretRef:
             name: {{ .Values.persistence.imageChartStorage.s3.existingSecret }}
@@ -239,6 +240,7 @@ spec:
             name: "{{ template "harbor.registryCtl" . }}"
         - secretRef:
             name: "{{ template "harbor.registry" . }}"
+            optional: true
         - secretRef:
             name: "{{ template "harbor.registryCtl" . }}"
         {{- if .Values.persistence.imageChartStorage.s3.existingSecret }}

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -1,4 +1,24 @@
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.registry" .) }}
+
+{{- $storage := .Values.persistence.imageChartStorage }}
+{{- $type := $storage.type }}
+
+{{- $createSecret := not .Values.registry.existingSecret}}
+{{- if not .Values.redis.external.existingSecret }}
+{{- $createSecret = true }}
+{{- end }}
+{{- if and (eq $type "azure") (not $storage.azure.existingSecret) }}
+{{- $createSecret = true }}
+{{- else if and (and (eq $type "gcs") (not $storage.gcs.existingSecret)) (not $storage.gcs.useWorkloadIdentity) }}
+{{- $createSecret = true }}
+{{- else if and (eq $type "s3") (not $storage.s3.existingSecret) }}
+{{- $createSecret = true }}
+{{- else if and (eq $type "swift") (not $storage.swift.existingSecret) }}
+{{- $createSecret = true }}
+{{- else if and (eq $type "oss") (not $storage.oss.existingSecret) }}
+{{- $createSecret = true }}
+{{- end }}
+{{- if $createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,8 +33,6 @@ data:
   {{- if not .Values.redis.external.existingSecret }}
   REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
   {{- end }}
-  {{- $storage := .Values.persistence.imageChartStorage }}
-  {{- $type := $storage.type }}
   {{- if and (eq $type "azure") (not $storage.azure.existingSecret) }}
   REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $storage.azure.accountkey | b64enc | quote }}
   {{- else if and (and (eq $type "gcs") (not $storage.gcs.existingSecret)) (not $storage.gcs.useWorkloadIdentity) }}
@@ -26,7 +44,7 @@ data:
   {{- if and (not $storage.s3.existingSecret) ($storage.s3.secretkey) }}
   REGISTRY_STORAGE_S3_SECRETKEY: {{ $storage.s3.secretkey | b64enc | quote }}
   {{- end }}
-  {{- else if and (eq $type "swift") (not ($storage.swift.existingSecret)) }}
+  {{- else if and (eq $type "swift") (not $storage.swift.existingSecret) }}
   REGISTRY_STORAGE_SWIFT_PASSWORD: {{ $storage.swift.password | b64enc | quote }}
   {{- if $storage.swift.secretkey }}
   REGISTRY_STORAGE_SWIFT_SECRETKEY: {{ $storage.swift.secretkey | b64enc | quote }}
@@ -34,9 +52,10 @@ data:
   {{- if $storage.swift.accesskey }}
   REGISTRY_STORAGE_SWIFT_ACCESSKEY: {{ $storage.swift.accesskey | b64enc | quote }}
   {{- end }}
-  {{- else if and (eq $type "oss") ((not ($storage.oss.existingSecret))) }}
+  {{- else if and (eq $type "oss") (not $storage.oss.existingSecret) }}
   REGISTRY_STORAGE_OSS_ACCESSKEYSECRET: {{ $storage.oss.accesskeysecret | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- if not .Values.registry.credentials.existingSecret }}
 ---
 apiVersion: v1


### PR DESCRIPTION
Updates the harbor chart to only create secrets for the various services if they have contents. This prevents empty secrets from being created for users configuring `existingSecret` values.

This should be effectively a no-op if the secret is used.