### PR TITLE
FEATURE: Adds layerinfo cache configuration

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -155,7 +155,7 @@ data:
         {{- end }}
       {{- end }}
       cache:
-        layerinfo: redis
+        layerinfo: {{ .Values.registry.layerCache }}
       maintenance:
         uploadpurging:
           {{- if .Values.registry.upload_purging.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -786,6 +786,9 @@ registry:
     # the interval of the purge operations
     interval: 24h
     dryrun: false
+  # configure layer caching storage driver.
+  # options are `redis`, `inmemory` - any other value will disable caching
+  layerCache: redis
 
 trivy:
   # enabled the flag to enable Trivy scanner


### PR DESCRIPTION
Addresses https://github.com/goharbor/harbor-helm/issues/1807

Have confirmed this using a testing harbor deployment:

`inmemory`:
```
registry time="2024-08-06T17:00:27.927677932Z" level=info msg="using inmemory blob descriptor cache" go.v
ersion=go1.22.5 instance.id=49ab6250-7ee6-4f61-9b9d-282f7a6eba88 service=registry version=v3.0.0-beta.1.m
+unknown
```

`none`/`disabled`/`etc`:
```
registry time="2024-08-06T17:03:39.210784328Z" level=warning msg="unknown cache type map[\"layerinfo\":\"
none\"], caching disabled" go.version=go1.22.5 instance.id=2f0e48d5-a489-4f10-ae97-7c0b5a7307ca service=r
egistry version=v3.0.0-beta.1.m+unknown
```

These are based on: https://github.com/distribution/distribution/blob/2801004c943f90f6e716f6c66564c73fb90f6d20/registry/handlers/app.go#L277