### PR TITLE
Remove ineffective 'args' from registry-dpl template.

### DIFF
--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -95,7 +95,6 @@ spec:
         {{- if not (empty .Values.containerSecurityContext) }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
         {{- end }}
-        args: ["serve", "/etc/registry/config.yml"]
         envFrom:
         - secretRef:
             name: "{{ template "harbor.registry" . }}"


### PR DESCRIPTION
This patch removes the 'args' field from the 'registry-dpl' Deployment template, as is was completely ignored by the upstream registry-photon image's entrypoint.sh script which does not accept/process any arguments in any way.

Fixes: https://github.com/goharbor/harbor-helm/issues/1801