### PR TITLE
Fix issue #1620

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $ingress := .Values.expose.ingress -}}
 {{- $tls := .Values.expose.tls -}}
 {{- if eq .Values.expose.ingress.controller "gce" }}
+  {{- $_ := set . "path_type" "ImplementationSpecific" -}}
   {{- $_ := set . "portal_path" "/*" -}}
   {{- $_ := set . "api_path" "/api/*" -}}
   {{- $_ := set . "service_path" "/service/*" -}}
@@ -9,6 +10,7 @@
   {{- $_ := set . "chartrepo_path" "/chartrepo/*" -}}
   {{- $_ := set . "controller_path" "/c/*" -}}
 {{- else if eq .Values.expose.ingress.controller "ncp" }}
+  {{- $_ := set . "path_type" "Prefix" -}}
   {{- $_ := set . "portal_path" "/.*" -}}
   {{- $_ := set . "api_path" "/api/.*" -}}
   {{- $_ := set . "service_path" "/service/.*" -}}
@@ -16,6 +18,7 @@
   {{- $_ := set . "chartrepo_path" "/chartrepo/.*" -}}
   {{- $_ := set . "controller_path" "/c/.*" -}}
 {{- else }}
+  {{- $_ := set . "path_type" "Prefix" -}}
   {{- $_ := set . "portal_path" "/" -}}
   {{- $_ := set . "api_path" "/api/" -}}
   {{- $_ := set . "service_path" "/service/" -}}
@@ -94,42 +97,42 @@ spec:
           servicePort: {{ template "harbor.portal.servicePort" . }}
 {{- else }}
       - path: {{ .api_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .service_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .v2_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .chartrepo_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .controller_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.core" . }}
             port:
               number: {{ template "harbor.core.servicePort" . }}
       - path: {{ .portal_path }}
-        pathType: Prefix
+        pathType: {{ .path_type }}
         backend:
           service:
             name: {{ template "harbor.portal" . }}


### PR DESCRIPTION
Hi,

I was hit by this, I see these errors in my ingress event logs
```
Warning  Translate  9m52s (x1702 over 7d7h)  loadbalancer-controller  Translation failed: invalid ingress spec: failed to validate prefix path /api/* due to invalid wildcard; failed to validate prefix path /service/* due to invalid wildcard; failed to validate prefix path /v2/* due to invalid wildcard; failed to validate prefix path /chartrepo/* due to invalid wildcard; failed to validate prefix path /c/* due to invalid wildcard; failed to validate prefix path /* due to invalid wildcard
```

I dug a bit and found #1620 and I figured these changes should fix the issue.