### PR TITLE
Refactor YAML to Use Template Values for Security Context

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -32,8 +32,8 @@ spec:
 {{- end }}
     spec:
       securityContext:
-        runAsUser: 999
-        fsGroup: 999
+        runAsUser: {{ .Values.database.securityContext.runAsUser }}
+        fsGroup: {{ .Values.database.securityContext.fsGroup }}
 {{- if .Values.database.internal.serviceAccountName }}
       serviceAccountName: {{ .Values.database.internal.serviceAccountName }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -960,6 +960,10 @@ database:
   ## Additional deployment labels
   podLabels: {}
 
+securityContext:
+  runAsUser: 999
+  fsGroup: 999
+  
 redis:
   # if external Redis is used, set "type" to "external"
   # and fill the connection information in "external" section


### PR DESCRIPTION
### Summary

This PR updates the YAML configuration to replace hardcoded values for `runAsUser` and `fsGroup` with templated values. This change enhances the configurability and maintainability of the configuration files.

### Details

- **Updated Security Context:**
  - Replaced hardcoded `runAsUser` value with `{{ .Values.database.securityContext.runAsUser }}`
  - Replaced hardcoded `fsGroup` value with `{{ .Values.database.securityContext.fsGroup }}`

These changes allow for more flexible configuration management by enabling the values to be defined dynamically based on the values provided in the Helm chart's values file.

### Impact

- **Configuration Flexibility:** This update improves the flexibility of configuration management, allowing different values to be easily set through the Helm values file.
- **Maintainability:** Centralizing configuration values in the Helm values file makes future updates easier and reduces the risk of errors associated with hardcoding values.

### How to Test

1. Ensure that the Helm values file (`values.yaml` or equivalent) contains the necessary `runAsUser` and `fsGroup` values under the `database.securityContext` section.
2. Deploy or render the Helm chart to verify that the YAML configuration reflects the templated values as expected.

### Additional Notes

- No functional changes are expected; this is a refactoring change.
- Reviewers should verify that the templated values are correctly applied during deployment.

Please review the changes and provide feedback.
