### PR TITLE
fix ci failure

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,31 +9,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [v1.25.3, v1.24.7, v1.23.13]
+        k8s_version: [v1.31.1, v1.30.4, v1.29.8]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.10.0
         with:
-          version: v0.17.0
+          version: v0.24.0
           node_image: kindest/node:${{ matrix.k8s_version }}
           cluster_name: kind-cluster-${{ matrix.k8s_version }}
           config: test/integration/kind-cluster.yaml
 
       - name: Install Nginx ingress controller
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.9.0/deploy/static/provider/kind/deploy.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.2/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s
 
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.23
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.19"
+          go-version: "1.23"
 
       - name: Cache go mod
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -59,7 +59,7 @@ jobs:
             kubectl -n default logs -l "component=$name" --all-containers > /tmp/harbor/$name.log ; \
           done
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: harbor_${{ matrix.k8s_version }}_${{ runner.os }}
@@ -71,7 +71,7 @@ jobs:
           mkdir -p /tmp/logs
           kind export logs --name kind-cluster-${{ matrix.k8s_version }} /tmp/logs
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: kind_v${{ matrix.k8s_version }}


### PR DESCRIPTION
update versions of
1, kind & kind-action
2, actions/checkout & upload-artifacts
3, ingress-controller
4, golang
5, kubernetes