### PR TITLE
Remove chartrepo location for nginx configmap

### DIFF
--- a/templates/nginx/configmap-http.yaml
+++ b/templates/nginx/configmap-http.yaml
@@ -90,21 +90,6 @@ data:
           proxy_request_buffering off;
         }
 
-        location /chartrepo/ {
-          proxy_pass {{ $scheme }}://core/chartrepo/;
-        {{- if and .Values.internalTLS.enabled }}
-          proxy_ssl_verify        off;
-          proxy_ssl_session_reuse on;
-        {{- end }}
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-
-          proxy_buffering off;
-          proxy_request_buffering off;
-        }
-
         location /c/ {
           proxy_pass {{ $scheme }}://core/c/;
           proxy_set_header Host $host;

--- a/templates/nginx/configmap-https.yaml
+++ b/templates/nginx/configmap-https.yaml
@@ -113,23 +113,6 @@ data:
           proxy_request_buffering off;
         }
 
-        location /chartrepo/ {
-          proxy_pass {{ $scheme }}://core/chartrepo/;
-        {{- if and .Values.internalTLS.enabled }}
-          proxy_ssl_verify        off;
-          proxy_ssl_session_reuse on;
-        {{- end }}
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-
-          proxy_cookie_path / "/; Secure";
-
-          proxy_buffering off;
-          proxy_request_buffering off;
-        }
-
         location /c/ {
           proxy_pass {{ $scheme }}://core/c/;
           proxy_set_header Host $host;


### PR DESCRIPTION
The chunk should be removed b/c it used to serve chart museum and it has been removed from Harbor