### PR TITLE
feat: core service ready/liveness probes to be configurable

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -317,6 +317,20 @@ app: "{{ template "harbor.name" . }}"
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.core.probe.httpGet" -}}
+httpGet:
+  path: /api/v2.0/ping
+  port: {{ template "harbor.core.containerPort" . }}
+  scheme: {{ include "harbor.component.scheme" . | upper }}
+{{- end -}}
+
+{{- define "harbor.core.probe" -}}
+failureThreshold: {{ .Values.core.readinessProbe.failureThreshold }}
+periodSeconds: {{ .Values.core.readinessProbe.periodSeconds }}
+timeoutSeconds: {{ .Values.core.readinessProbe.timeoutSeconds }}
+{{ include "harbor.core.probe.httpGet" . }}
+{{- end -}}
+
 {{/* core component container port */}}
 {{- define "harbor.core.containerPort" -}}
   {{- if .Values.internalTLS.enabled -}}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -68,28 +68,15 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
           failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
           periodSeconds: 10
+          {{- include "harbor.core.probe.httpGet" . | nindent 10 }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+        {{- include "harbor.core.probe" . | nindent 10 }}
         readinessProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+        {{- include "harbor.core.probe" . | nindent 10 }}
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.core" . }}"

--- a/values.yaml
+++ b/values.yaml
@@ -565,6 +565,16 @@ core:
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
+  ## Readiness probe values
+  readinessProbe:
+    failureThreshold: 2
+    periodSeconds: 10
+    timeoutSeconds: 1
+  ## Liveness probe values
+  livenessProbe:
+    failureThreshold: 2
+    periodSeconds: 10
+    timeoutSeconds: 1
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
Allows for core probes to be configurable. I understand most operations should take less than 1 second and they seem too. However there's points where I've found especially when using the AWS VPC CNI. The probe takes greater than a second, it's extremely hard to prove exactly why. However, when I patch the timeoutSeconds to 10 seconds the 503s caused by the readiness probe failing go away.

I've noticed people have asked for this and have been shot down. I'm hoping a PR is better received.

Cheers