### PR TITLE
feat: core service ready/liveness probes to be configurable

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -317,6 +317,20 @@ app: "{{ template "harbor.name" . }}"
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.core.probe.httpGet" -}}
+httpGet:
+  path: /api/v2.0/ping
+  port: {{ template "harbor.core.containerPort" . }}
+  scheme: {{ include "harbor.component.scheme" . | upper }}
+{{- end -}}
+
+{{- define "harbor.core.probe" -}}
+failureThreshold: {{ .probe.failureThreshold }}
+periodSeconds: {{ .probe.periodSeconds }}
+timeoutSeconds: {{ .probe.timeoutSeconds }}
+{{ include "harbor.core.probe.httpGet" .Values }}
+{{- end -}}
+
 {{/* core component container port */}}
 {{- define "harbor.core.containerPort" -}}
   {{- if .Values.internalTLS.enabled -}}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -68,28 +68,15 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
           failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
           periodSeconds: 10
+          {{- include "harbor.core.probe.httpGet" . | nindent 10 }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+        {{- include "harbor.core.probe" (dict "probe" .Values.core.livenessProbe) | nindent 10 }}
         readinessProbe:
-          httpGet:
-            path: /api/v2.0/ping
-            scheme: {{ include "harbor.component.scheme" . | upper }}
-            port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+        {{- include "harbor.core.probe" (dict "probe" .Values.core.readinessProbe) | nindent 10 }}
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.core" . }}"

--- a/values.yaml
+++ b/values.yaml
@@ -565,6 +565,16 @@ core:
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
+  ## Readiness probe values
+  readinessProbe:
+    failureThreshold: 2
+    periodSeconds: 10
+    timeoutSeconds: 1
+  ## Liveness probe values
+  livenessProbe:
+    failureThreshold: 2
+    periodSeconds: 10
+    timeoutSeconds: 1
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
Recently ran into an issue on our cluster that has a lot of churn (we use karpenter and leverage spot instances pretty heavily). For some reason there are points when a new node in the cluster comes up and the AWS VPC CNI resyncs we see a bit of latency. I couldn't quite figure out why.  The 1 second timeout on the readiness probe procs fails quite a bit causing noise in our events monitoring as well as sometimes restarting the container when it seems otherwise healthy. 

The only way I found to solve the issue is to increase the `timeoutSeconds`. 

Let me know what you all think.

Cheers 