### PR TITLE
Provide more TLS names which will be valid for the TLS cert

### DIFF
--- a/templates/internal/auto-tls.yaml
+++ b/templates/internal/auto-tls.yaml
@@ -1,7 +1,10 @@
 {{- if and .Values.internalTLS.enabled (eq .Values.internalTLS.certSource "auto") }}
 {{- $ca := genCA "harbor-internal-ca" 365 }}
 {{- $coreCN := (include "harbor.core" .) }}
-{{- $coreCrt := genSignedCert $coreCN (list "127.0.0.1") (list "localhost" $coreCN) 365 $ca }}
+{{- $coreCNPlusNS := printf "%s.%s" $coreCN .Release.Namespace }}
+{{- $coreCNPlusNSsvc := printf "%s.svc" $coreCNPlusNS }}
+{{- $coreCNPlusNSsvcCluster := printf "%s.cluster.local" $coreCNPlusNSsvc }}
+{{- $coreCrt := genSignedCert $coreCN (list "127.0.0.1") (list "localhost" $coreCN $coreCNPlusNS $coreCNPlusNSsvc $coreCNPlusNSsvcCluster) 365 $ca }}
 {{- $jsCN := (include "harbor.jobservice" .) }}
 {{- $jsCrt := genSignedCert $jsCN nil (list $jsCN) 365 $ca }}
 {{- $regCN := (include "harbor.registry" .) }}


### PR DESCRIPTION
The names are:

- `127.0.0.1` (existing)
- `localhost` (existing)
- `{{ .Release.Name }}` (existing)
- `{{ .Release.Name }}.{{ .Release.Namespace }}` (new)
- `{{ .Release.Name }}.{{ .Release.Namespace }}.svc` (new)
- `{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local` (new)