### PR TITLE
Remove unused mount in core-dpl.yaml

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -179,8 +179,6 @@ spec:
         - name: core-internal-certs
           mountPath: /etc/harbor/ssl/core
         {{- end }}
-        - name: psc
-          mountPath: /etc/core/token
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
@@ -236,8 +234,6 @@ spec:
         secret:
           secretName: {{ template "harbor.internalTLS.core.secretName" . }}
       {{- end }}
-      - name: psc
-        emptyDir: {}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}


### PR DESCRIPTION
Remove the unused mount /etc/core/token from core deployment.
PR also made in https://github.com/goharbor/harbor/pull/21709 which is based on the issue https://github.com/goharbor/harbor/issues/21706