### PR TITLE
Feat/add.OIDC configuration

### DIFF
--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -31,7 +31,7 @@ data:
   {{- if not .Values.core.existingXsrfSecret }}
   CSRF_KEY: {{ .Values.core.xsrfKey | default (include "harbor.secretKeyHelper" (dict "key" "CSRF_KEY" "data" $existingSecret.data)) | default (randAlphaNum 32) | b64enc | quote }}
   {{- end }}
-{{- if .Values.core.configureUserSettings }}
-  CONFIG_OVERWRITE_JSON: {{ .Values.core.configureUserSettings | b64enc | quote }}
-{{- end }}
+  {{- if or (not (quote .Values.core.configureUserSettings | empty))  .Values.core.oidc }}
+  CONFIG_OVERWRITE_JSON: {{ (toString (toJson (merge (fromJson (.Values.core.configureUserSettings | default "{}")) (fromJson (include "harbor.oidcConfigSecret" . | default "{}"))))) | b64enc | quote }}
+  {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}

--- a/test/unittest/core_secret_test.yaml
+++ b/test/unittest/core_secret_test.yaml
@@ -29,7 +29,7 @@ tests:
           value: "dGVzdC1hZG1pbi1wYXNzd29yZA=="
       - equal:
           path: data.CONFIG_OVERWRITE_JSON
-          value: "eyJ0ZXN0IjogInRlc3QifQ=="
+          value: "eyJ0ZXN0IjoidGVzdCJ9"
 
   - it: ExistingSecretSecretKey
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -596,6 +596,20 @@ core:
   #   command: [ 'sh', '-c', "sleep 20" ]
   ## User settings configuration json string
   configureUserSettings:
+  ## Configure oidc authentication
+  # Example:
+  #   name: keycloak
+  #   endpoint: https://keycloak/realms/harbor
+  #   groupsClaim: roles
+  #   adminGroup: admin
+  #   clientId: harbor
+  #   clientSecret: ""
+  #   scope: openid,email,offline_access,profile,roles
+  #   verifyCert: false
+  #   autoOnboard: true
+  #   userClaim: email
+  # If clientSecret is not specified, set existingClientSecretName and existingClientSecretKey to use an existing secret
+  oidc: {}
   # The provider for updating project quota(usage), there are 2 options, redis or db.
   # By default it is implemented by db but you can configure it to redis which
   # can improve the performance of high concurrent pushing to the same project,


### PR DESCRIPTION
Added oidc configuration in helm chart. User can provide existing client secret or insert it explicitly in values.
All configuration specified will be merged with configureUserSettings json and passed to CONFIG_OVERWRITE_JSON variable.
Additionally json merge provides validation of configureUserSettings, preventing passing invalid json into it.

Previous - https://github.com/goharbor/harbor-helm/pull/1826
was stalled due to no activity from maintainers, please consider merging it again
