### PR TITLE
fix: improve helm lookup fallback in case of helm template rendering

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -56,8 +56,8 @@ app: "{{ template "harbor.name" . }}"
 
 {{/* Helper for printing values from existing secrets*/}}
 {{- define "harbor.secretKeyHelper" -}}
-  {{- if and (not (empty .data)) (hasKey .data .key) }}
-    {{- index .data .key | b64dec -}}
+  {{- if and (not (empty (.data | default dict ))) (hasKey (.data | default dict ) .key) }}
+    {{- index (.data | default dict ) .key | b64dec -}}
   {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -112,8 +112,8 @@ app: "{{ template "harbor.name" . }}"
 {{- define "harbor.database.rawPassword" -}}
   {{- if eq .Values.database.type "internal" -}}
     {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.database" .) -}}
-    {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "POSTGRES_PASSWORD") -}}
-      {{- .Values.database.internal.password | default (index $existingSecret.data "POSTGRES_PASSWORD" | b64dec) -}}
+    {{- if and (not (empty $existingSecret)) (hasKey ($existingSecret.data | default dict) "POSTGRES_PASSWORD") -}}
+      {{- .Values.database.internal.password | default (index ($existingSecret.data | default dict) "POSTGRES_PASSWORD" | b64dec) -}}
     {{- else -}}
       {{- .Values.database.internal.password -}}
     {{- end -}}


### PR DESCRIPTION
To re-PR for a **closed** bot-marked stale one (approved but wrongly assumed for it to be auto-merged): goharbor/harbor-helm#1897

This improve the case of using `helm template .` to statically render the resources. Without this, it might produce error similar to the following even with default `values.yaml`

```
Error: template: harbor/templates/registry/registry-secret.yaml:12:62: executing "harbor/templates/registry/registry-secret.yaml" at <include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" $existingSecret.data)>: error calling include: template: harbor/templates/_helpers.tpl:59:41: executing "harbor.secretKeyHelper" at <.data>: wrong type for value; expected map[string]interface {}; got interface {}
```