### PR TITLE
Fix: fix bug where log level configuration was not applied

### DIFF
--- a/templates/jobservice/jobservice-cm-env.yaml
+++ b/templates/jobservice/jobservice-cm-env.yaml
@@ -15,6 +15,8 @@ data:
   JOBSERVICE_WEBHOOK_JOB_MAX_RETRY: "{{ .Values.jobservice.notification.webhook_job_max_retry }}"
   JOBSERVICE_WEBHOOK_JOB_HTTP_CLIENT_TIMEOUT: "{{ .Values.jobservice.notification.webhook_job_http_client_timeout }}"
 
+  LOG_LEVEL: "{{ .Values.logLevel }}"
+  
   {{- if has "jobservice" .Values.proxy.components }}
   HTTP_PROXY: "{{ .Values.proxy.httpProxy }}"
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"


### PR DESCRIPTION
## Summary

Ensure `LOG_LEVEL` is set in the `harbor-jobservice-env` ConfigMap so that the `jobservice` correctly respects the `logLevel` value from `values.yaml`.

## Changes

- Add `LOG_LEVEL` to the `harbor-jobservice-env` ConfigMap based on the `logLevel` field in `values.yaml`.
- Align the logging behavior of `jobservice` with that of `core`, which already respects the `LOG_LEVEL` environment variable.

## Fixes

Fixes #2166