### PR TITLE
Fix ArgoCD sync

### DIFF
--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -139,7 +139,9 @@ spec:
     {{- end }}
   {{- if and .Values.persistence.enabled (not $database.existingClaim) }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1	
+    kind: PersistentVolumeClaim
+    metadata:
       name: "database-data"
       labels:
 {{ include "harbor.legacy.labels" . | indent 8 }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -102,7 +102,9 @@ spec:
     {{- end }}
   {{- if and .Values.persistence.enabled (not $redis.existingClaim) }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1	
+    kind: PersistentVolumeClaim
+    metadata:
       name: data
       labels:
 {{ include "harbor.legacy.labels" . | indent 8 }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -207,7 +207,9 @@ spec:
     {{- end }}
 {{- if and .Values.persistence.enabled (not $trivy.existingClaim) }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1	
+    kind: PersistentVolumeClaim
+    metadata:
       name: data
       labels:
 {{ include "harbor.legacy.labels" . | indent 8 }}


### PR DESCRIPTION
As per https://github.com/goharbor/harbor-helm/issues/2174, adds the missing PVC manifest properties `apiVersion` and `kind`, so that ArgoCD can properly sync:

Symptoms:
![image](https://github.com/user-attachments/assets/e425e5c0-2048-44d2-8011-4e1ba3b74173)
![image](https://github.com/user-attachments/assets/13272399-315a-4566-8203-75be5dcb48af)

Cause:
![image](https://github.com/user-attachments/assets/a8708d4b-4f3d-474e-823f-db731312d5b1)

Fix: see [Files changed](https://github.com/goharbor/harbor-helm/pull/2173/files). 