### PR TITLE
Support per-service external Redis instances for Harbor services

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -171,13 +171,14 @@ data:
       redirect:
         disable: {{ $storage.disableredirect }}
     redis:
-      addr: {{ template "harbor.redis.addr" . }}
+      addr: {{ template "harbor.redis.addrFor" (list "registry" .) }}
       {{- if eq "redis+sentinel" (include "harbor.redis.scheme" .) }}
       sentinelMasterSet: {{ template "harbor.redis.masterSet" . }}
       {{- end }}
       db: {{ template "harbor.redis.dbForRegistry" . }}
-      {{- if not (eq (include "harbor.redis.password" .) "") }}
-      password: {{ template "harbor.redis.password" . }}
+      {{- $pwd := (include "harbor.redis.passwordFor" (list "registry" .)) }}
+      {{- if ne $pwd "" }}
+      password: {{ $pwd }}
       {{- end }}
       readtimeout: 10s
       writetimeout: 10s

--- a/templates/registry/registry-secret.yaml
+++ b/templates/registry/registry-secret.yaml
@@ -11,8 +11,8 @@ data:
   {{- if not .Values.registry.existingSecret }}
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" $existingSecret.data)) | default (randAlphaNum 16) | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.redis.external.existingSecret }}
-  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
+  {{- if not (or .Values.redis.external.services.registry.existingSecret .Values.redis.external.existingSecret) }}
+  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.passwordFor" (list "registry" .) | b64enc | quote }}
   {{- end }}
   {{- $storage := .Values.persistence.imageChartStorage }}
   {{- $type := $storage.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -1031,6 +1031,20 @@ redis:
     password: ""
     # If using existingSecret, the key must be REDIS_PASSWORD
     existingSecret: ""
+    # service-specific redis connection configuration
+    # all fields are optional, if not set, each service falls back to the global configuration
+    services:
+      core:
+        addr: ""
+        username: ""
+        password: ""
+        # If using existingSecret, the key must be REDIS_PASSWORD
+        existingSecret: ""
+      jobservice: {}
+      registry: {}
+      trivyAdapter: {}
+      harbor: {}
+      cacheLayer: {}
   ## Additional deployment annotations
   podAnnotations: {}
   ## Additional deployment labels


### PR DESCRIPTION
## What this PR does

This PR adds support for configuring separate external Redis instances for each Harbor service component (core, jobservice, registry, trivyAdapter, etc.).

Currently, Harbor Helm chart only supports connecting all services to a single Redis instance and separates their data using logical DBs (database index). However, many enterprise-grade Redis offerings (such as managed Redis services and Redis Enterprise) do not support logical databases, and only database index 0 is available.

This limitation prevents Harbor from working as intended when using such external Redis services.

### What's changed

- Added a new `services:` block under `redis.external` in `values.yaml` to configure per-service overrides for:
  - `addr`
  - `username`
  - `password`
  - `existingSecret`
- Extended Helm templates:
  - `addrFor`, `passwordFor`, `credFor` now prioritize `services.<svc>.addr` etc. before falling back to global settings.
- Updated `registry-cm.yaml` and `registry-secret.yaml` to use new per-service Redis credentials.
- Fully backward compatible: if no per-service values are provided, Harbor behaves exactly as before.
- Legacy flat keys like `coreAddr`, `registryAddr`, etc. remain supported for now.

### Why this is needed

When using external Redis services where logical DBs are not available (DB index always 0), each Harbor component must connect to a separate Redis instance to prevent data collisions and ensure Harbor works properly.

This PR allows users to configure Harbor cleanly for such environments without needing complex workarounds.

### Example values.yaml structure

```yaml
redis:
  type: external
  external:
    addr: redis.shared:6379
    username: ""
    password: ""
    existingSecret: ""

    services:
      core:
        addr: redis-core:6379
        username: coreuser
        password: corepass
      jobservice:
        addr: redis-job:6379
        existingSecret: redis-jobsecret
      registry:
        addr: redis-registry:6379
        password: regpass
