### PR TITLE
Add Content-Security-Policy header templating for portal

### DIFF
--- a/templates/portal/configmap.yaml
+++ b/templates/portal/configmap.yaml
@@ -63,6 +63,9 @@ data:
             }
             location = /index.html {
                 add_header Cache-Control "no-store, no-cache, must-revalidate";
+                {{- with .Values.portal.contentSecurityPolicy }}
+                add_header Content-Security-Policy {{ . }}
+                {{- end }}
             }
         }
     }

--- a/values.yaml
+++ b/values.yaml
@@ -566,6 +566,7 @@ portal:
   # - name: wait
   #   image: busybox
   #   command: [ 'sh', '-c', "sleep 20" ]
+  contentSecurityPolicy: ""
 
 core:
   image:


### PR DESCRIPTION
I wanted to option to add Content-Security-Policy headers for Harbor portal.
This adds templating to be able to configure this, setting the default to an empty string keeping the config the same as before the addition of this templating.

If preferred the templating could be more generic for adding any type of headers, not only Content-Security-Policy.
Let me know if there is another recommended way for configuring CSPs in Harbor, or if it would be preferred to add this as meta tag instead in the html?