### PR TITLE
feat: add support to configure securityContext

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -36,9 +36,9 @@ spec:
 {{ toYaml .Values.core.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
 {{- if .Values.core.serviceAccountName }}
       serviceAccountName: {{ .Values.core.serviceAccountName }}
 {{- end -}}

--- a/templates/core/core-pre-upgrade-job.yaml
+++ b/templates/core/core-pre-upgrade-job.yaml
@@ -20,9 +20,9 @@ spec:
         component: migrator
     spec:
       restartPolicy: Never
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
 {{- if .Values.core.serviceAccountName }}
       serviceAccountName: {{ .Values.core.serviceAccountName }}
 {{- end -}}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -36,9 +36,9 @@ spec:
 {{ toYaml .Values.exporter.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
 {{- if .Values.exporter.serviceAccountName }}
       serviceAccountName: {{ .Values.exporter.serviceAccountName }}
 {{- end -}}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -42,9 +42,9 @@ spec:
 {{ toYaml .Values.jobservice.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
 {{- if .Values.jobservice.serviceAccountName }}
       serviceAccountName: {{ .Values.jobservice.serviceAccountName }}
 {{- end -}}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -40,9 +40,9 @@ spec:
 {{- if .Values.nginx.serviceAccountName }}
       serviceAccountName: {{ .Values.nginx.serviceAccountName }}
 {{- end }}
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -34,9 +34,9 @@ spec:
 {{ toYaml .Values.portal.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -44,10 +44,9 @@ spec:
 {{ toYaml .Values.registry.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
-        fsGroupChangePolicy: OnRootMismatch
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
 {{- if .Values.registry.serviceAccountName }}
       serviceAccountName: {{ .Values.registry.serviceAccountName }}
 {{- end -}}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -43,9 +43,9 @@ spec:
 {{- if .Values.trivy.serviceAccountName }}
       serviceAccountName: {{ .Values.trivy.serviceAccountName }}
 {{- end }}
-      securityContext:
-        runAsUser: 10000
-        fsGroup: 10000
+      {{- if not (empty .Values.securityContext) }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.trivy.automountServiceAccountToken | default false }}
 {{- with .Values.trivy.topologySpreadConstraints}}
       topologySpreadConstraints:

--- a/values.yaml
+++ b/values.yaml
@@ -482,8 +482,15 @@ cache:
   # default keep cache for one day.
   expireHours: 24
 
+## set Security Context to comply with PSP restricted policy if necessary
+## securityContext:{} is initially an empty yaml that you could edit it on demand, we just filled with a common template for convenience
+securityContext:
+  runAsUser: 10000
+  fsGroup: 10000
+  fsGroupChangePolicy: OnRootMismatch
+
 ## set Container Security Context to comply with PSP restricted policy if necessary
-## each of the conatiner will apply the same security context
+## each of the container will apply the same security context
 ## containerSecurityContext:{} is initially an empty yaml that you could edit it on demand, we just filled with a common template for convenience
 containerSecurityContext:
   privileged: false


### PR DESCRIPTION
Following the logic of this PR : https://github.com/goharbor/harbor-helm/pull/1695 to avoid error such as the one below when deploying on an Openshift cluster.

```
.spec.securityContext.fsGroup: Invalid value: []int64{10000}: 10000 is not an allowed group, provider restricted-v2: .containers[0].runAsUser: Invalid value: 10000: must be in the ranges: [1000870000, 1000879999]
```

Example test:
```
helm template . --set metrics.enabled=true --set securityContext="" --show-only templates/exporter/
exporter-dpl.yaml 
```