### PR TITLE
Add optional s3.ForcePathStyle value

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -86,6 +86,9 @@ data:
         {{- if $storage.s3.multipartcopythresholdsize }}
         multipartcopythresholdsize: {{ $storage.s3.multipartcopythresholdsize }}
         {{- end }}
+        {{- if $storage.s3.forcepathstyle }}
+        forcepathstyle: {{ $storage.s3.forcepathstyle }}
+        {{- end }}
       {{- else if eq $type "swift" }}
       swift:
         authurl: {{ $storage.swift.authurl }}

--- a/values.yaml
+++ b/values.yaml
@@ -242,6 +242,7 @@ persistence:
       #multipartcopychunksize: "33554432"
       #multipartcopymaxconcurrency: 100
       #multipartcopythresholdsize: "33554432"
+      #forcepathstyle: false
     swift:
       authurl: https://storage.myprovider.com/v3/auth
       username: username


### PR DESCRIPTION
Adds a ForcePathStyle argument to s3 driver parameters, to allow s3 endpoints like s3.domain/bucket. See here for the argument in the [StorageDriver parameters](https://github.com/distribution/distribution/blob/4ead5a108593cec429ec57d0eb698d5825e037d0/registry/storage/driver/s3-aws/s3.go#L100)

This allows users to set "persistence.imageChartStorage.s3.forcepathstyle" to make harbor use an S3 URL like "s3.endpoint/bucket-name" rather than "bucket-name.s3.endpoint". I was using a s3 provider other than AWS and came across the issue that harbor was calling the bucket with a URL like the second, and it wasn't working for my use-case. This change fixed the issue. 

My first contribution so apologies if I missed anything!