### PR TITLE
Fix values for gateway-apis HTTPRoute parentRefs

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 expose:
-  # Set how to expose the service. Set the type as "ingress", "clusterIP", "nodePort" or "loadBalancer"
+  # Set how to expose the service. Set the type as "ingress", "clusterIP", "nodePort", "loadBalancer" or "route"
   # and fill the information in the corresponding section
   type: ingress
   tls:
@@ -51,14 +51,16 @@ expose:
   route:
     labels: {}
     annotations: {}
+    # References to the parent gateways
+    parentRefs: []
       # - name: envoy-internal
       #   namespace: networking
       #   sectionName: https
       #   group: gateway.networking.k8s.io
       #   kind: Gateway
-    parentRefs: {}
-      # - "harbor.example.com"
+    # The hostnames for the HTTPRoute
     hosts: []
+      # - "harbor.example.com"
   clusterIP:
     # The name of ClusterIP service
     name: harbor


### PR DESCRIPTION
I found that the following configuration while valid does not translate to a working yaml manifest:
```
expose:
  type: "route"
  route:
    parentRefs:
    - name: private-gateway-prd
      namespace: gateways
    hosts:
    - "harbor.example.com"
```
When I try to run `helm template` with these values I got the following error:
```
Error: YAML parse error on harbor/templates/gateway-apis/route.yaml: error converting YAML to JSON: yaml: line 9: could not find expected ':'
```
It seems that the indentation is wrong [here](https://github.com/goharbor/harbor-helm/blob/065fd42506639320a842b368b258795ee1735844/templates/gateway-apis/route.yaml#L25-L28).

This PR fixes this error and allows helm template to work, I also updated the comments in the `values.yaml`  file to include references to this feature.
