### PR TITLE
Add monitoring port names to the harbor component deployments.

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -155,6 +155,9 @@ spec:
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
         {{- end }}
         ports:
+        - containerPort: {{ .Values.metrics.core.port }}
+          name: {{ template "harbor.metricsPortName" . }}
+          protocol: TCP
         - containerPort: {{ template "harbor.core.containerPort" . }}
         volumeMounts:
         - name: config

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -106,6 +106,8 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.metrics.exporter.port }}
+          name: {{ template "harbor.metricsPortName" . }}
+          protocol: TCP
         volumeMounts:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -133,6 +133,8 @@ spec:
             name: "{{ template "harbor.jobservice" . }}"
         ports:
         - containerPort: {{ template "harbor.jobservice.containerPort" . }}
+          name: {{ template "harbor.metricsPortName" . }}
+          protocol: TCP
         volumeMounts:
         - name: jobservice-config
           mountPath: /etc/jobservice/config.yml

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -90,6 +90,8 @@ spec:
           periodSeconds: 10
         ports:
         - containerPort: {{ template "harbor.portal.containerPort" . }}
+          name: {{ template "harbor.metricsPortName" . }}
+          protocol: TCP
         volumeMounts:
         - name: portal-config
           mountPath: /etc/nginx/nginx.conf

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -176,6 +176,8 @@ spec:
         ports:
         - containerPort: {{ template "harbor.registry.containerPort" . }}
         - containerPort: {{ ternary .Values.metrics.registry.port 5001 .Values.metrics.enabled }}
+          name: {{ template "harbor.metricsPortName" . }}
+          protocol: TCP
         volumeMounts:
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}


### PR DESCRIPTION
We use  grafana alloy with its pod discovery feature, it is way easier to identify the metrics ports if they are correctly named in the manifests.