### PR TITLE
Skip creating core/jobservice secrets when using external secrets

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -604,3 +604,39 @@ app: "{{ template "harbor.name" . }}"
 {{- define "harbor.ingress.kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.expose.ingress.kubeVersionOverride -}}
 {{- end -}}
+
+{{/*
+Determine if the core secret should be created.
+Returns "true" if any data field would be populated, "false" if all fields use external secrets.
+*/}}
+{{- define "harbor.core.createSecret" -}}
+  {{- $needsSecretKey := not .Values.existingSecretSecretKey -}}
+  {{- $needsCoreSecret := not .Values.core.existingSecret -}}
+  {{- $needsTokenCert := not .Values.core.secretName -}}
+  {{- $needsAdminPassword := not .Values.existingSecretAdminPassword -}}
+  {{- $needsDbPassword := and (not .Values.database.external.existingSecret) (eq .Values.database.type "external") -}}
+  {{- $needsRegistryPassword := not .Values.registry.credentials.existingSecret -}}
+  {{- $needsCsrfKey := not .Values.core.existingXsrfSecret -}}
+  {{- $needsConfigOverwrite := .Values.core.configureUserSettings -}}
+  {{- $needsJaegerPassword := and .Values.trace.enabled (eq .Values.trace.provider "jaeger") -}}
+  {{- if or $needsSecretKey $needsCoreSecret $needsTokenCert $needsAdminPassword $needsDbPassword $needsRegistryPassword $needsCsrfKey $needsConfigOverwrite $needsJaegerPassword -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Determine if the jobservice secret should be created.
+Returns "true" if any data field would be populated, "false" if all fields use external secrets.
+*/}}
+{{- define "harbor.jobservice.createSecret" -}}
+  {{- $needsJobserviceSecret := not .Values.jobservice.existingSecret -}}
+  {{- $needsRegistryPassword := not .Values.registry.credentials.existingSecret -}}
+  {{- $needsJaegerPassword := and .Values.trace.enabled (eq .Values.trace.provider "jaeger") -}}
+  {{- if or $needsJobserviceSecret $needsRegistryPassword $needsJaegerPassword -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "harbor.core.createSecret" .) "true" }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.core" .) }}
 apiVersion: v1
 kind: Secret
@@ -35,3 +36,4 @@ data:
   CONFIG_OVERWRITE_JSON: {{ .Values.core.configureUserSettings | b64enc | quote }}
 {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}
+{{- end }}

--- a/templates/jobservice/jobservice-secrets.yaml
+++ b/templates/jobservice/jobservice-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "harbor.jobservice.createSecret" .) "true" }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "harbor.jobservice" .) }}
 apiVersion: v1
 kind: Secret
@@ -15,3 +16,4 @@ data:
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
   {{- end }}
   {{- template "harbor.traceJaegerPassword" . }}
+{{- end }}


### PR DESCRIPTION
Hello, I noticed that when you move all secrets to an external (non-helm generated) source - the secrets still remain and cause confusion for peers.

I thought about adding a helper function and if everything is moved, then we do not create a secret at all.