### PR TITLE
Modify htpasswdString example in values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -785,7 +785,7 @@ registry:
     # If using existingSecret, the key must be REGISTRY_PASSWD and REGISTRY_HTPASSWD
     existingSecret: ""
     # Login and password in htpasswd string format. Excludes `registry.credentials.username`  and `registry.credentials.password`. May come in handy when integrating with tools like argocd or flux. This allows the same line to be generated each time the template is rendered, instead of the `htpasswd` function from helm, which generates different lines each time because of the salt.
-    # htpasswdString: $apr1$XLefHzeG$Xl4.s00sMSCCcMyJljSZb0 # example string
+    # htpasswdString: "harbor_registry_user:$2a$05$IPnI.TSgP8ek1/ESjkULVemA.A3nSXPdN80ljsmcun7FtE3ViSYUq" # example string, bcrypt is the only accepted hashing algorithm in htpasswd here.
     htpasswdString: ""
   middleware:
     enabled: false


### PR DESCRIPTION
This PR updates the `htpasswd` string example in `values.yaml`.

The underlying code exclusively supports the `bcrypt` hashing algorithm:

https://github.com/goharbor/distribution/blob/523791cb5f2b3316a26a44206c2a97d51eb9ef92/registry/auth/htpasswd/htpasswd.go#L32-L49

The previous example was misleading because it used the unsupported APR1 (MD5) algorithm and failed to specify a username. This update corrects the format to include the username and demonstrates the required bcrypt hash.