### PR TITLE
fix: Update OCI registry publishing in release workflow

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -22,10 +22,8 @@ jobs:
         run: echo "PACKAGE_PATH=$(helm package . | awk '{print $NF}')" >> $GITHUB_ENV
       - name: Publish Helm Chart
         run: |
-          helm registry login registry-1.docker.io -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
-          helm push ${{ env.PACKAGE_PATH }} oci://registry-1.docker.io/${{ secrets.DOCKER_HUB_USERNAME }}
           helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          helm push ${{ env.PACKAGE_PATH }} oci://ghcr.io/${{ github.actor }}
+          helm push ${{ env.PACKAGE_PATH }} oci://ghcr.io/$GITHUB_REPOSITORY_OWNER
       - name: Upload to chart repository
         run: |
           git config --global user.email "${{ github.event.repository.name }}@users.noreply.github.com"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -22,8 +25,8 @@ jobs:
         run: echo "PACKAGE_PATH=$(helm package . | awk '{print $NF}')" >> $GITHUB_ENV
       - name: Publish Helm Chart
         run: |
-          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          helm push ${{ env.PACKAGE_PATH }} oci://ghcr.io/$GITHUB_REPOSITORY_OWNER
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm push ${{ env.PACKAGE_PATH }} oci://ghcr.io/${{ github.repository_owner }}
       - name: Upload to chart repository
         run: |
           git config --global user.email "${{ github.event.repository.name }}@users.noreply.github.com"


### PR DESCRIPTION
## Description
This PR fixes the OCI registry publishing issue in the release workflow.

## Changes
- Remove Docker Hub push that fails with authentication errors due to missing credentials
- Fix GHCR push to use the organization path (`ghcr.io/goharbor`) instead of personal account (`ghcr.io/${{ github.actor }}`)
- Properly authenticate using `GITHUB_TOKEN` which is available in GitHub Actions

## Fixes
Closes #2265