### PR TITLE
feat(s3): add forcepathstyle support

### DIFF
--- a/templates/registry/registry-cm.yaml
+++ b/templates/registry/registry-cm.yaml
@@ -86,6 +86,9 @@ data:
         {{- if $storage.s3.multipartcopythresholdsize }}
         multipartcopythresholdsize: {{ $storage.s3.multipartcopythresholdsize }}
         {{- end }}
+        {{- if $storage.s3.forcepathstyle }}
+        forcepathstyle: {{ $storage.s3.forcepathstyle }}
+        {{- end }}
       {{- else if eq $type "swift" }}
       swift:
         authurl: {{ $storage.swift.authurl }}

--- a/values.yaml
+++ b/values.yaml
@@ -244,6 +244,7 @@ persistence:
       #multipartcopychunksize: "33554432"
       #multipartcopymaxconcurrency: 100
       #multipartcopythresholdsize: "33554432"
+      #forcepathstyle: false
     swift:
       authurl: https://storage.myprovider.com/v3/auth
       username: username


### PR DESCRIPTION
I saw there was an effort to add `forcepathstyle` at https://github.com/goharbor/harbor-helm/pull/2248/changes in the past.
I saw upstream `distribution` already added `AWS_S3_FORCE_PATH_STYLE` at https://github.com/goharbor/distribution/blob/523791cb5f2b3316a26a44206c2a97d51eb9ef92/registry/storage/driver/s3-aws/s3_test.go#L43
So maybe it is a good time to add again.