### PR TITLE
Allow configuring registries for proxy cache and replication whitelist

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -53,8 +53,8 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory"
-  REPLICATION_ADAPTER_WHITELIST: "ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "{{ .Values.core.permittedRegistryTypesForProxyCache | join "," }}"
+  REPLICATION_ADAPTER_WHITELIST: "{{ .Values.core.replicationAdapterWhitelist | join "," }}"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"

--- a/values.yaml
+++ b/values.yaml
@@ -670,6 +670,31 @@ core:
     deleteUser: false
     auditLogsCompliant: false
 
+  permittedRegistryTypesForProxyCache:
+    - docker-hub
+    - harbor
+    - azure-acr
+    - ali-acr
+    - aws-ecr
+    - google-gcr
+    - docker-registry
+    - github-ghcr
+    - jfrog-artifactory
+
+  replicationAdapterWhitelist:
+    - ali-acr
+    - aws-ecr
+    - azure-acr
+    - docker-hub
+    - docker-registry
+    - github-ghcr
+    - google-gcr
+    - harbor
+    - huawei-SWR
+    - jfrog-artifactory
+    - tencent-tcr
+    - volcengine-cr
+
 jobservice:
   image:
     repository: docker.io/goharbor/harbor-jobservice


### PR DESCRIPTION
The PR https://github.com/goharbor/harbor-helm/pull/2223 changed these environment variables, but removing `quay` specifically affected some users.

I did not add more documentation to the entries because not even the Harbor codebase documented them well, although they seem very straight forward to understand.