### PR TITLE
Changed default tag to use chart app version instead of floating version tag

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -604,3 +604,13 @@ app: "{{ template "harbor.name" . }}"
 {{- define "harbor.ingress.kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.expose.ingress.kubeVersionOverride -}}
 {{- end -}}
+
+{{/* 
+  Default image tag if not set.
+  If Chart.AppVersion starts with a digit (referencing a version), 
+  prefix it with 'v' to align helm app version with docker tag.
+*/}}
+{{- define "harbor.defaultImageTag" -}}
+  {{- $app := .Chart.AppVersion -}}
+  {{- ternary (printf "v%s" $app) $app (regexMatch "^[0-9]" $app) -}}
+{{- end -}}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       containers:
       - name: core
-        image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
+        image: {{ .Values.core.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.core.startupProbe.enabled }}
         startupProbe:

--- a/templates/core/core-pre-upgrade-job.yaml
+++ b/templates/core/core-pre-upgrade-job.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
       - name: core-job
-        image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
+        image: {{ .Values.core.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.core.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/harbor/harbor_core", "-mode=migrate"]
         envFrom:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -49,7 +49,7 @@ spec:
       # use this init container to correct the permission
       # as "fsGroup" applied before the init container running, the container has enough permission to execute the command
       - name: "data-permissions-ensurer"
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+        image: {{ .Values.database.internal.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if not (empty .Values.containerSecurityContext) }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
@@ -69,7 +69,7 @@ spec:
       {{- end }}
       containers:
       - name: database
-        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
+        image: {{ .Values.database.internal.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if not (empty .Values.containerSecurityContext) }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -59,7 +59,7 @@ spec:
 {{- end }}
       containers:
       - name: exporter
-        image: {{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}
+        image: {{ .Values.exporter.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.exporter.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -70,7 +70,7 @@ spec:
       {{- end }}
       containers:
       - name: jobservice
-        image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
+        image: {{ .Values.jobservice.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.jobservice.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       {{- end }}
       containers:
       - name: portal
-        image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}
+        image: {{ .Values.portal.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.portal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- if .Values.portal.resources }}
         resources:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - name: redis
-        image: {{ .Values.redis.internal.image.repository }}:{{ .Values.redis.internal.image.tag }}
+        image: {{ .Values.redis.internal.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.redis.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if not (empty .Values.containerSecurityContext) }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       containers:
       - name: registry
-        image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
+        image: {{ .Values.registry.registry.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.registry.registry.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:
@@ -211,7 +211,7 @@ spec:
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       - name: registryctl
-        image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
+        image: {{ .Values.registry.controller.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       containers:
         - name: trivy
-          image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
+          image: {{ .Values.trivy.image.repository }}:{{- default (include "harbor.defaultImageTag" .) .Values.trivy.image.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if not (empty .Values.containerSecurityContext) }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -501,7 +501,8 @@ containerSecurityContext:
 nginx:
   image:
     repository: docker.io/goharbor/nginx-photon
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -536,7 +537,8 @@ nginx:
 portal:
   image:
     repository: docker.io/goharbor/harbor-portal
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -580,7 +582,8 @@ portal:
 core:
   image:
     repository: docker.io/goharbor/harbor-core
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -673,7 +676,8 @@ core:
 jobservice:
   image:
     repository: docker.io/goharbor/harbor-jobservice
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   replicas: 1
   podDisruptionBudget:
     enabled: false
@@ -743,7 +747,8 @@ registry:
   registry:
     image:
       repository: docker.io/goharbor/registry-photon
-      tag: dev
+      # By default the version of the chart will be used as the tag
+      # tag: dev
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -752,7 +757,8 @@ registry:
   controller:
     image:
       repository: docker.io/goharbor/harbor-registryctl
-      tag: dev
+      # By default the version of the chart will be used as the tag
+      # tag: dev
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -837,7 +843,8 @@ trivy:
     # repository the repository for Trivy adapter image
     repository: docker.io/goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -946,7 +953,8 @@ database:
   internal:
     image:
       repository: docker.io/goharbor/harbor-db
-      tag: dev
+      # By default the version of the chart will be used as the tag
+      # tag: dev
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     # mount the service account token
@@ -1026,7 +1034,8 @@ redis:
   internal:
     image:
       repository: docker.io/goharbor/redis-photon
-      tag: dev
+      # By default the version of the chart will be used as the tag
+      # tag: dev
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     # mount the service account token
@@ -1096,7 +1105,8 @@ redis:
 exporter:
   image:
     repository: docker.io/goharbor/harbor-exporter
-    tag: dev
+    # By default the version of the chart will be used as the tag
+    # tag: dev
   serviceAccountName: ""
   # mount the service account token
   automountServiceAccountToken: false


### PR DESCRIPTION
This PR would be a fix for #2306 

In this PR I made a new helper that has a default value for the image tags that works as follows:
It defaults to the app version set in the deployment.
If it starts with a digit, aka pointing to a version like 2.14.2, a `v` will be prepended to make the final result `v2.14.2` which is the format used for the Docker images. If a non-digit is detected, nothing is prepended, resulting in a 1:1 copy of the version string.
`dev` -> `dev` 