### PR TITLE
fix: reuse existing secretKey and TLS certs to prevent ArgoCD drift

### DIFF
--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -9,15 +9,22 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.existingSecretSecretKey }}
-  secretKey: {{ .Values.secretKey | b64enc | quote }}
+  secretKey: {{ .Values.secretKey | default (include "harbor.secretKeyHelper" (dict "key" "secretKey" "data" $existingSecret.data)) | default "not-a-secure-key" | b64enc | quote }}
   {{- end }}
   {{- if not .Values.core.existingSecret }}
   secret: {{ .Values.core.secret | default (include "harbor.secretKeyHelper" (dict "key" "secret" "data" $existingSecret.data)) | default (randAlphaNum 16) | b64enc | quote }}
   {{- end }}
   {{- if not .Values.core.secretName }}
+  {{- $existingKey := include "harbor.secretKeyHelper" (dict "key" "tls.key" "data" $existingSecret.data) }}
+  {{- $existingCert := include "harbor.secretKeyHelper" (dict "key" "tls.crt" "data" $existingSecret.data) }}
+  {{- if and $existingKey $existingCert }}
+  tls.key: {{ .Values.core.tokenKey | default $existingKey | b64enc | quote }}
+  tls.crt: {{ .Values.core.tokenCert | default $existingCert | b64enc | quote }}
+  {{- else }}
   {{- $ca := genCA "harbor-token-ca" 365 }}
   tls.key: {{ .Values.core.tokenKey | default $ca.Key | b64enc | quote }}
   tls.crt: {{ .Values.core.tokenCert | default $ca.Cert | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}


### PR DESCRIPTION
## Summary

When using ArgoCD or other GitOps tools, the helm template is rendered on each sync. This causes unnecessary secret updates and pod restarts because:

1. `secretKey` did not use the `lookup` function to check for existing values
2. TLS certificates (`tls.key`, `tls.crt`) were always regenerated with `genCA`

## Changes

- **secretKey**: Add lookup fallback to reuse existing value from the cluster
- **tls.key/tls.crt**: Check for existing certificates before generating new ones with `genCA`

## How it works

The fix follows the same pattern already used for `secret` and `CSRF_KEY`:

```yaml
# Before (secretKey)
secretKey: {{ .Values.secretKey | b64enc | quote }}

# After (secretKey)
secretKey: {{ .Values.secretKey | default (include "harbor.secretKeyHelper" ...) | default "not-a-secure-key" | b64enc | quote }}
```

For TLS certificates, we check if both `tls.key` and `tls.crt` exist in the current secret before falling back to `genCA`.

## Testing

- [x] `helm template` renders successfully
- [x] Fresh install: generates new secrets as expected
- [x] Existing install: reuses existing values (no drift)

Closes #2263