### PR TITLE
fix: resolve argocd diff in httproute

### DIFF
--- a/templates/gateway-apis/route.yaml
+++ b/templates/gateway-apis/route.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   parentRefs:
   {{- toYaml $route.parentRefs | nindent 2 }}
-  hostnames: 
+  hostnames:
   {{- toYaml $route.hosts | nindent 2 }}
   rules:
   - matches:
@@ -43,6 +43,9 @@ spec:
     backendRefs:
     - name: {{ template "harbor.core" . }}
       namespace: {{ .Release.Namespace | quote }}
+      group: ""
+      kind: Service
+      weight: 1
       port: {{ template "harbor.core.servicePort" . }}
   - matches:
     - path:
@@ -51,5 +54,8 @@ spec:
     backendRefs:
     - name: {{ template "harbor.portal" . }}
       namespace: {{ .Release.Namespace | quote }}
+      group: ""
+      kind: Service
+      weight: 1
       port: {{ template "harbor.portal.servicePort" . }}
 {{- end }}


### PR DESCRIPTION
These values get set by default so Argocd complains about a diff in the route definition.

<img width="1556" height="772" alt="image" src="https://github.com/user-attachments/assets/2f426233-695c-41e9-925c-2810f722b66e" />
