### PR TITLE
feat: make health probe timeoutSeconds and failureThreshold configurable via values

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -72,24 +72,32 @@ spec:
             path: /api/v2.0/ping
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 360
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
-          periodSeconds: 10
+          periodSeconds: {{ .Values.core.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.core.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.core.startupProbe.failureThreshold }}
+          successThreshold: {{ .Values.core.startupProbe.successThreshold }}
         {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v2.0/ping
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.core.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.core.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.core.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.core.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.core.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /api/v2.0/ping
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 2
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.core.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.core.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.core.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.core.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.core.readinessProbe.successThreshold }}
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.core" . }}"

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -78,16 +78,20 @@ spec:
           exec:
             command:
             - /docker-healthcheck.sh
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.database.internal.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.database.internal.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.database.internal.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.database.internal.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.database.internal.livenessProbe.successThreshold }}
         readinessProbe:
           exec:
             command:
             - /docker-healthcheck.sh
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.database.internal.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.database.internal.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.database.internal.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.database.internal.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.database.internal.readinessProbe.successThreshold }}
 {{- if .Values.database.internal.resources }}
         resources:
 {{ toYaml .Values.database.internal.resources | indent 10 }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -65,14 +65,20 @@ spec:
           httpGet:
             path: /
             port: {{ .Values.metrics.exporter.port }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.exporter.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.exporter.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.exporter.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.exporter.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.exporter.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /
             port: {{ .Values.metrics.exporter.port }}
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.exporter.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.exporter.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.exporter.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.exporter.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.exporter.readinessProbe.successThreshold }}
         args: ["-log-level", "{{ .Values.logLevel }}"]
         envFrom:
         - configMapRef:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -77,15 +77,21 @@ spec:
             path: /api/v1/stats
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.jobservice.containerPort" . }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.jobservice.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jobservice.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jobservice.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.jobservice.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.jobservice.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /api/v1/stats
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.jobservice.containerPort" . }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.jobservice.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jobservice.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jobservice.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.jobservice.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.jobservice.readinessProbe.successThreshold }}
 {{- if .Values.jobservice.resources }}
         resources:
 {{ toYaml .Values.jobservice.resources | indent 10 }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -73,15 +73,21 @@ spec:
             scheme: {{ .scheme }}
             path: /
             port: {{ .port }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.nginx.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nginx.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.nginx.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.nginx.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.nginx.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             scheme: {{ .scheme }}
             path: /
             port: {{ .port }}
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.nginx.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nginx.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.nginx.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.nginx.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.nginx.readinessProbe.successThreshold }}
 {{- if .Values.nginx.resources }}
         resources:
 {{ toYaml .Values.nginx.resources | indent 10 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -79,15 +79,21 @@ spec:
             path: /
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.portal.containerPort" . }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.portal.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.portal.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.portal.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.portal.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.portal.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.portal.containerPort" . }}
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.portal.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.portal.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.portal.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.portal.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.portal.readinessProbe.successThreshold }}
         ports:
         - containerPort: {{ template "harbor.portal.containerPort" . }}
         volumeMounts:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -56,13 +56,19 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6379
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.redis.internal.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.internal.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.redis.internal.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.redis.internal.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.redis.internal.livenessProbe.successThreshold }}
         readinessProbe:
           tcpSocket:
             port: 6379
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.redis.internal.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.internal.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.redis.internal.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.redis.internal.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.redis.internal.readinessProbe.successThreshold }}
 {{- if .Values.redis.internal.resources }}
         resources:
 {{ toYaml .Values.redis.internal.resources | indent 10 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -80,15 +80,21 @@ spec:
             path: /
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.registry.containerPort" . }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.registry.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.registry.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.registry.registry.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.registry.registry.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.registry.registry.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.registry.containerPort" . }}
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.registry.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.registry.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.registry.registry.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.registry.registry.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.registry.registry.readinessProbe.successThreshold }}
 {{- if .Values.registry.registry.resources }}
         resources:
 {{ toYaml .Values.registry.registry.resources | indent 10 }}
@@ -211,15 +217,21 @@ spec:
             path: /api/health
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.registryctl.containerPort" . }}
-          initialDelaySeconds: 300
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.controller.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.controller.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.registry.controller.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.registry.controller.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.registry.controller.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /api/health
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.registryctl.containerPort" . }}
-          initialDelaySeconds: 1
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.controller.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.controller.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.registry.controller.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.registry.controller.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.registry.controller.readinessProbe.successThreshold }}
 {{- if .Values.registry.controller.resources }}
         resources:
 {{ toYaml .Values.registry.controller.resources | indent 10 }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -160,19 +160,21 @@ spec:
               scheme: {{ include "harbor.component.scheme" . | upper }}
               path: /probe/healthy
               port: api-server
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.trivy.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.trivy.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.trivy.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.trivy.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.trivy.livenessProbe.successThreshold }}
           readinessProbe:
             httpGet:
               scheme: {{ include "harbor.component.scheme" . | upper }}
               path: /probe/ready
               port: api-server
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.trivy.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.trivy.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.trivy.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.trivy.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.trivy.readinessProbe.successThreshold }}
           resources:
 {{ toYaml .Values.trivy.resources | indent 12 }}
       {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}

--- a/test/unittest/core/core_deployment_test.yaml
+++ b/test/unittest/core/core_deployment_test.yaml
@@ -183,6 +183,79 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.periodSeconds
           value: 10
 
+  - it: StartupProbeCustom
+    set:
+      core:
+        startupProbe:
+          enabled: true
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 100
+          successThreshold: 1
+    template: templates/core/core-dpl.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 20
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 100
+
+  - it: LivenessProbeCustom
+    set:
+      core:
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 5
+          successThreshold: 1
+    template: templates/core/core-dpl.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 20
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+
+  - it: ReadinessProbeCustom
+    set:
+      core:
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 3
+          failureThreshold: 10
+          successThreshold: 1
+    template: templates/core/core-dpl.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 10
+
   - it: ExistingSecretAdminPassword
     set:
       existingSecretAdminPassword: HARBOR_ADMIN_PASSWORD

--- a/values.yaml
+++ b/values.yaml
@@ -532,6 +532,20 @@ nginx:
   podLabels: {}
   ## The priority class to run the pod as
   priorityClassName:
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
 
 portal:
   image:
@@ -569,6 +583,20 @@ portal:
   serviceAnnotations: {}
   ## The priority class to run the pod as
   priorityClassName:
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   # containers to be run before the controller's container starts.
   initContainers: []
   # Example:
@@ -595,6 +623,24 @@ core:
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 360
+    successThreshold: 1
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 2
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 2
+    successThreshold: 1
   # resources:
   #  requests:
   #    memory: 256Mi
@@ -689,6 +735,20 @@ jobservice:
   #   requests:
   #     memory: 256Mi
   #     cpu: 100m
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   extraEnvVars: []
   nodeSelector: {}
   tolerations: []
@@ -750,6 +810,20 @@ registry:
     #    memory: 256Mi
     #    cpu: 100m
     extraEnvVars: []
+    ## Liveness probe values
+    livenessProbe:
+      initialDelaySeconds: 300
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
+    ## Readiness probe values
+    readinessProbe:
+      initialDelaySeconds: 1
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
   controller:
     image:
       repository: docker.io/goharbor/harbor-registryctl
@@ -759,6 +833,20 @@ registry:
     #    memory: 256Mi
     #    cpu: 100m
     extraEnvVars: []
+    ## Liveness probe values
+    livenessProbe:
+      initialDelaySeconds: 300
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
+    ## Readiness probe values
+    readinessProbe:
+      initialDelaySeconds: 1
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -857,6 +945,20 @@ trivy:
     limits:
       cpu: 1
       memory: 1Gi
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   extraEnvVars: []
   nodeSelector: {}
   tolerations: []
@@ -956,12 +1058,20 @@ database:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
-    # The timeout used in livenessProbe; 1 to 5 seconds
+    ## Liveness probe values
     livenessProbe:
+      initialDelaySeconds: 300
+      periodSeconds: 10
       timeoutSeconds: 1
-    # The timeout used in readinessProbe; 1 to 5 seconds
+      failureThreshold: 3
+      successThreshold: 1
+    ## Readiness probe values
     readinessProbe:
+      initialDelaySeconds: 1
+      periodSeconds: 10
       timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
     extraEnvVars: []
     nodeSelector: {}
     tolerations: []
@@ -1036,6 +1146,20 @@ redis:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+    ## Liveness probe values
+    livenessProbe:
+      initialDelaySeconds: 300
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
+    ## Readiness probe values
+    readinessProbe:
+      initialDelaySeconds: 1
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      successThreshold: 1
     extraEnvVars: []
     nodeSelector: {}
     tolerations: []
@@ -1111,6 +1235,20 @@ exporter:
   #  requests:
   #    memory: 256Mi
   #    cpu: 100m
+  ## Liveness probe values
+  livenessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  ## Readiness probe values
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   extraEnvVars: []
   podAnnotations: {}
   ## Additional deployment labels


### PR DESCRIPTION
## Summary

- Expose all five probe timing parameters (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`, `successThreshold`) as configurable values for all 9 components: core, portal, jobservice, registry (registry + registryctl), nginx, exporter, trivy, database, and redis
- Defaults match current hardcoded values exactly — zero behavioral change on upgrade
- Add unit tests for custom probe overrides on core (startup, liveness, readiness)

Closes #2316

## Motivation

Health probe settings are currently hardcoded in templates and cannot be overridden via `values.yaml`. This causes issues in environments with higher network latency (e.g. China regions), where the default 1s timeout and low failure thresholds trigger unnecessary pod restarts and 502 errors.

## Test plan

- [ ] `helm template` before/after diff shows only newly-explicit fields (timeoutSeconds, failureThreshold, successThreshold) that were previously Kubernetes implicit defaults — no behavioral change
- [ ] All 105 existing + new unit tests pass (`helm unittest -f 'test/unittest/**/*_test.yaml' .`)
- [ ] Spot-check: `helm template . --set core.livenessProbe.timeoutSeconds=5 --set core.livenessProbe.failureThreshold=5` renders custom values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)