### PR TITLE
feat: added support hostAliases

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -58,6 +58,10 @@ spec:
             component: core
 {{- end }}
 {{- end }}
+      {{- with .Values.core.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- with .Values.core.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -57,6 +57,10 @@ spec:
             component: exporter
 {{- end }}
 {{- end }}
+      {{- with .Values.exporter.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: exporter
         image: {{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -64,6 +64,10 @@ spec:
             component: jobservice
 {{- end }}
 {{- end }}
+      {{- with .Values.jobservice.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- with .Values.jobservice.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -58,6 +58,10 @@ spec:
             component: nginx
 {{- end }}
 {{- end }}
+      {{- with .Values.nginx.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: nginx
         image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -55,6 +55,10 @@ spec:
             component: portal
 {{- end }}
 {{- end }}
+      {{- with .Values.portal.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- with .Values.portal.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -67,6 +67,10 @@ spec:
             component: registry
 {{- end }}
 {{- end }}
+      {{- with .Values.registry.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- with .Values.registry.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -517,6 +517,7 @@ nginx:
   #    memory: 256Mi
   #    cpu: 100m
   extraEnvVars: []
+  hostAliases: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -552,6 +553,7 @@ portal:
   #    memory: 256Mi
   #    cpu: 100m
   extraEnvVars: []
+  hostAliases: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -600,6 +602,7 @@ core:
   #    memory: 256Mi
   #    cpu: 100m
   extraEnvVars: []
+  hostAliases: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -692,6 +695,7 @@ jobservice:
   #     memory: 256Mi
   #     cpu: 100m
   extraEnvVars: []
+  hostAliases: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -768,6 +772,7 @@ registry:
     minAvailable: 1
     # maxUnavailable: 1
   revisionHistoryLimit: 10
+  hostAliases: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -1111,6 +1116,7 @@ exporter:
   #    memory: 256Mi
   #    cpu: 100m
   extraEnvVars: []
+  hostAliases: []
   podAnnotations: {}
   ## Additional deployment labels
   podLabels: {}


### PR DESCRIPTION
# Added hostAliases support to all Harbor Helm Deployments:
- core
- portal
- jobservice
- registry
- nginx
- exporter

This enables consistent host alias customization across all Harbor components without breaking existing installs.
Default behavior is unchanged because `hostAliases` is empty by default.

# Changes
1. Updated Deployment templates to render spec.template.spec.hostAliases conditionally from values:
```yaml
{{- with .Values.<component>.hostAliases }}
hostAliases:
{{ toYaml . | indent 8 }}
{{- end }}
```
2. Added default values in values.yaml:
```yaml
nginx:
  hostAliases: []
portal:
  hostAliases: []
core:
  hostAliases: []
jobservice:
  hostAliases: []
registry:
  hostAliases: []
exporter:
  hostAliases: []
```

# Validation
- `helm template harbor .` passes with default values.
- `helm template harbor . -f /tmp/harbor-hostaliases-all-values.yaml` passes with sample `hostAliases` overrides.
- Verified `hostAliases` appears in rendered Deployment manifests when configured.