### PR TITLE
parametrize gracePeriodTerminationSeconds

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -47,7 +47,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.core.automountServiceAccountToken | default false }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.core.terminationGracePeriodSeconds }}
 {{- with .Values.core.topologySpreadConstraints}}
       topologySpreadConstraints:
 {{- range . }}

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -69,12 +69,12 @@ spec:
         {{- if .Values.core.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: /api/v2.0/ping
+            path: {{ .Values.core.startupProbe.path }}
             scheme: {{ include "harbor.component.scheme" . | upper }}
             port: {{ template "harbor.core.containerPort" . }}
-          failureThreshold: 360
+          failureThreshold: {{ .Values.core.startupProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.core.startupProbe.initialDelaySeconds }}
-          periodSeconds: 10
+          periodSeconds: {{ .Values.core.startupProbe.periodSeconds }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/templates/core/core-pre-upgrade-job.yaml
+++ b/templates/core/core-pre-upgrade-job.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.core.terminationGracePeriodSeconds }}
       containers:
       - name: core-job
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.database.internal.automountServiceAccountToken | default false }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.database.internal.terminationGracePeriodSeconds }}
       initContainers:
       # with "fsGroup" set, each time a volume is mounted, Kubernetes must recursively chown() and chmod() all the files and directories inside the volume
       # this causes the postgresql reports the "data directory /var/lib/postgresql/data/pgdata has group or world access" issue when using some CSIs e.g. Ceph

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -53,7 +53,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.jobservice.automountServiceAccountToken | default false }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.jobservice.terminationGracePeriodSeconds }}
 {{- with .Values.jobservice.topologySpreadConstraints}}
       topologySpreadConstraints:
 {{- range . }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.redis.internal.automountServiceAccountToken | default false }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.redis.internal.terminationGracePeriodSeconds }}
       {{- with .Values.redis.internal.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -56,7 +56,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.registry.automountServiceAccountToken | default false }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.registry.terminationGracePeriodSeconds }}
 {{- with .Values.registry.topologySpreadConstraints}}
       topologySpreadConstraints:
 {{- range . }}

--- a/values.yaml
+++ b/values.yaml
@@ -669,6 +669,7 @@ core:
   gdpr:
     deleteUser: false
     auditLogsCompliant: false
+  terminationGracePeriodSeconds: 120
 
 jobservice:
   image:
@@ -741,6 +742,7 @@ jobservice:
   # By default, the timeout is set to 30 minutes. This field only needs be re-configured if a longer request timeout is required. 
   # the value assigned to timeout should be a number without min, e.g. registryHttpClientTimeout: 60 configures the timeout to 60 minutes
   registryHttpClientTimeout: 30
+  terminationGracePeriodSeconds: 120
 
 registry:
   registry:
@@ -805,6 +807,7 @@ registry:
   existingSecretKey: REGISTRY_HTTP_SECRET
   # If true, the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL.
   relativeurls: false
+  terminationGracePeriodSeconds: 120
   credentials:
     username: "harbor_registry_user"
     password: "harbor_registry_password"
@@ -994,6 +997,8 @@ database:
       #  requests:
       #    memory: 128Mi
       #    cpu: 100m
+      #
+    terminationGracePeriodSeconds: 120
   external:
     host: "192.168.0.1"
     port: "5432"
@@ -1061,6 +1066,7 @@ redis:
     trivyAdapterIndex: "5"
     # harborDatabaseIndex: "6"
     # cacheLayerDatabaseIndex: "7"
+    terminationGracePeriodSeconds: 120
   external:
     # support redis, redis+sentinel
     # addr for redis: <host_redis>:<port_redis>

--- a/values.yaml
+++ b/values.yaml
@@ -594,7 +594,10 @@ core:
   ## Startup probe values
   startupProbe:
     enabled: true
+    path: /api/v2.0/ping
     initialDelaySeconds: 10
+    failureThreshold: 360
+    periodSeconds: 10
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
These options makes sense to be parametrize for huge clusters which may need more time to terminate pods, e.g. during database migrations.