### PR TITLE
fix: remove duplicate entries in values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -685,8 +685,6 @@ jobservice:
   serviceAccountName: ""
   # mount the service account token
   automountServiceAccountToken: false
-  replicas: 1
-  revisionHistoryLimit: 10
   # resources:
   #   requests:
   #     memory: 256Mi


### PR DESCRIPTION
the parameters "replicas" and "revisionHistoryLimit" are duplicated in the values.yaml file, under the "jobservice" category