### PR TITLE
Bump version to 1.19.0, appVersion to 2.15.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor
-version: 1.4.0-dev
-appVersion: dev
+version: 1.19.0
+appVersion: 2.15.0
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:
 - docker

--- a/values.yaml
+++ b/values.yaml
@@ -501,7 +501,7 @@ containerSecurityContext:
 nginx:
   image:
     repository: docker.io/goharbor/nginx-photon
-    tag: dev
+    tag: v2.15.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -550,7 +550,7 @@ nginx:
 portal:
   image:
     repository: docker.io/goharbor/harbor-portal
-    tag: dev
+    tag: v2.15.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -608,7 +608,7 @@ portal:
 core:
   image:
     repository: docker.io/goharbor/harbor-core
-    tag: dev
+    tag: v2.15.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -719,7 +719,7 @@ core:
 jobservice:
   image:
     repository: docker.io/goharbor/harbor-jobservice
-    tag: dev
+    tag: v2.15.0
   replicas: 1
   podDisruptionBudget:
     enabled: false
@@ -804,7 +804,7 @@ registry:
   registry:
     image:
       repository: docker.io/goharbor/registry-photon
-      tag: dev
+      tag: v2.15.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -827,7 +827,7 @@ registry:
   controller:
     image:
       repository: docker.io/goharbor/harbor-registryctl
-      tag: dev
+      tag: v2.15.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -926,7 +926,7 @@ trivy:
     # repository the repository for Trivy adapter image
     repository: docker.io/goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
-    tag: dev
+    tag: v2.15.0
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token
@@ -1049,7 +1049,7 @@ database:
   internal:
     image:
       repository: docker.io/goharbor/harbor-db
-      tag: dev
+      tag: v2.15.0
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     # mount the service account token
@@ -1137,7 +1137,7 @@ redis:
   internal:
     image:
       repository: docker.io/goharbor/redis-photon
-      tag: dev
+      tag: v2.15.0
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     # mount the service account token
@@ -1221,7 +1221,7 @@ redis:
 exporter:
   image:
     repository: docker.io/goharbor/harbor-exporter
-    tag: dev
+    tag: v2.15.0
   serviceAccountName: ""
   # mount the service account token
   automountServiceAccountToken: false


### PR DESCRIPTION
Bumping the versions used in the HelmChart to `appVersion: 2.15.0` and Chart `version: 1.19.0`

I'm unsure where this PR needs to point to, though. Please help me out so I can correct this.