### PR TITLE
Digest pinning support for Trivy image.

### DIFF
--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       containers:
         - name: trivy
-          image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
+          image: {{ .Values.trivy.image.repository }}{{- if .Values.trivy.image.digest }}@{{ .Values.trivy.image.digest }}{{- else }}:{{ .Values.trivy.image.tag }}{{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if not (empty .Values.containerSecurityContext) }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -927,6 +927,10 @@ trivy:
     repository: docker.io/goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
     tag: dev
+    # The image digest to pull.
+    # If set, it takes precedence over the image tag.
+    # Example: sha256:...
+    digest: ""
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # mount the service account token


### PR DESCRIPTION
## Summary

This change adds optional digest support for the Harbor Trivy adapter image.

Currently the Trivy StatefulSet always renders the image as:

```
  <repository>:<tag>
```

This makes it impossible to use digest-based image references such as:

```
  goharbor/trivy-adapter-photon@sha256:<digest>
```

The new `trivy.image.digest` value is optional and backward compatible:
- when `trivy.image.digest` is empty, the chart keeps rendering `<repository>:<tag>`
- when `trivy.image.digest` is set, the chart renders `<repository>@<digest>`

This allows users to pin the Trivy adapter image by immutable digest while preserving the existing tag-based behavior by default.