### PR TITLE
Support existing secret for the full external DB connection

### DIFF
--- a/templates/core/core-cm.yaml
+++ b/templates/core/core-cm.yaml
@@ -15,10 +15,12 @@ data:
     httpport = {{ ternary "8443" "8080" .Values.internalTLS.enabled }}
   PORT: "{{ ternary "8443" "8080" .Values.internalTLS.enabled }}"
   DATABASE_TYPE: "postgresql"
+  {{- if not .Values.database.external.existingSecret.enabled }}
   POSTGRESQL_HOST: "{{ template "harbor.database.host" . }}"
   POSTGRESQL_PORT: "{{ template "harbor.database.port" . }}"
   POSTGRESQL_USERNAME: "{{ template "harbor.database.username" . }}"
   POSTGRESQL_DATABASE: "{{ template "harbor.database.coreDatabase" . }}"
+  {{- end }}
   POSTGRESQL_SSLMODE: "{{ template "harbor.database.sslmode" . }}"
   POSTGRESQL_MAX_IDLE_CONNS: "{{ .Values.database.maxIdleConns }}"
   POSTGRESQL_MAX_OPEN_CONNS: "{{ .Values.database.maxOpenConns }}"

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -135,12 +135,40 @@ spec:
           - name: INTERNAL_TLS_TRUST_CA_PATH
             value: /etc/harbor/ssl/core/ca.crt
           {{- end }}
-          {{- if .Values.database.external.existingSecret }}
+          {{- if .Values.database.external.existingSecret.enabled }}
+          - name: POSTGRESQL_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.external.existingSecret.name }}
+                key: {{ .Values.database.external.existingSecret.keys.host }}
+          {{- end }}
+          {{- if .Values.database.external.existingSecret.enabled }}
+          - name: POSTGRESQL_PORT
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.external.existingSecret.name }}
+                key: {{ .Values.database.external.existingSecret.keys.port }}
+          {{- end }}
+          {{- if .Values.database.external.existingSecret.enabled }}
+          - name: POSTGRESQL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.external.existingSecret.name }}
+                key: {{ .Values.database.external.existingSecret.keys.username }}
+          {{- end }}
+          {{- if .Values.database.external.existingSecret.enabled }}
           - name: POSTGRESQL_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.database.external.existingSecret }}
-                key: password
+                name: {{ .Values.database.external.existingSecret.name }}
+                key: {{ .Values.database.external.existingSecret.keys.password }}
+          {{- end }}
+          {{- if .Values.database.external.existingSecret.enabled }}
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.external.existingSecret.name }}
+                key: {{ .Values.database.external.existingSecret.keys.coreDatabase }}
           {{- end }}
           {{- if .Values.registry.credentials.existingSecret }}
           - name: REGISTRY_CREDENTIAL_PASSWORD

--- a/templates/core/core-pre-upgrade-job.yaml
+++ b/templates/core/core-pre-upgrade-job.yaml
@@ -41,13 +41,41 @@ spec:
             name: "{{ template "harbor.core" . }}"
         - secretRef:
             name: "{{ template "harbor.core" . }}"
-        {{- if .Values.database.external.existingSecret }}
         env:
-          - name: POSTGRESQL_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.database.external.existingSecret }}
-                key: password
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: POSTGRESQL_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.host }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: POSTGRESQL_PORT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.port }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: POSTGRESQL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.username }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.password }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.coreDatabase }}
         {{- end }}
         {{- if not (empty .Values.containerSecurityContext) }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}

--- a/templates/core/core-secret.yaml
+++ b/templates/core/core-secret.yaml
@@ -22,7 +22,7 @@ data:
   {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.database.external.existingSecret }}
+  {{- if not .Values.database.external.existingSecret.enabled }}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
   {{- end }}
   {{- if not .Values.registry.credentials.existingSecret }}

--- a/templates/exporter/exporter-cm-env.yaml
+++ b/templates/exporter/exporter-cm-env.yaml
@@ -26,10 +26,12 @@ data:
   HARBOR_SERVICE_SCHEME: "{{ template "harbor.component.scheme" . }}"
   HARBOR_SERVICE_HOST: "{{ template "harbor.core" . }}"
   HARBOR_SERVICE_PORT: "{{ template "harbor.core.servicePort" . }}"
+  {{- if not .Values.database.external.existingSecret.enabled }}
   HARBOR_DATABASE_HOST: "{{ template "harbor.database.host" . }}"
   HARBOR_DATABASE_PORT: "{{ template "harbor.database.port" . }}"
   HARBOR_DATABASE_USERNAME: "{{ template "harbor.database.username" . }}"
   HARBOR_DATABASE_DBNAME: "{{ template "harbor.database.coreDatabase" . }}"
+  {{- end }}
   HARBOR_DATABASE_SSLMODE: "{{ template "harbor.database.sslmode" . }}"
   HARBOR_DATABASE_MAX_IDLE_CONNS: "{{ .Values.database.maxIdleConns }}"
   HARBOR_DATABASE_MAX_OPEN_CONNS: "{{ .Values.database.maxOpenConns }}"

--- a/templates/exporter/exporter-dpl.yaml
+++ b/templates/exporter/exporter-dpl.yaml
@@ -86,12 +86,40 @@ spec:
         - secretRef:
             name: "{{ template "harbor.exporter" . }}"
         env:
-        {{- if .Values.database.external.existingSecret }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: HARBOR_DATABASE_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.host }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: HARBOR_DATABASE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.port }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: HARBOR_DATABASE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.username }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
         - name: HARBOR_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.database.external.existingSecret }}
-              key: password
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.password }}
+        {{- end }}
+        {{- if .Values.database.external.existingSecret.enabled }}
+        - name: HARBOR_DATABASE_DBNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.external.existingSecret.name }}
+              key: {{ .Values.database.external.existingSecret.keys.coreDatabase }}
         {{- end }}
         {{- if .Values.existingSecretAdminPassword }}
         - name: HARBOR_ADMIN_PASSWORD

--- a/templates/exporter/exporter-secret.yaml
+++ b/templates/exporter/exporter-secret.yaml
@@ -11,7 +11,7 @@ data:
 {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
 {{- end }}
-{{- if not .Values.database.external.existingSecret }}
+{{- if not .Values.database.external.existingSecret.enabled }}
   HARBOR_DATABASE_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1108,8 +1108,16 @@ database:
     username: "user"
     password: "password"
     coreDatabase: "registry"
-    # if using existing secret, the key must be "password"
-    existingSecret: ""
+    # Use an external secret and provide key mappings
+    existingSecret:
+      enabled: false
+      name: "my-external-secret-name"
+      keys:
+        host: host
+        port: port
+        username: username
+        password: password
+        coreDatabase: dbName
     # "disable" - No SSL
     # "require" - Always SSL (skip verification)
     # "verify-ca" - Always SSL (verify that the certificate presented by the


### PR DESCRIPTION
Closes #2381.

Revives the change from #1783 (closed unmerged), rebased on current `main`.

### What

Today, with an external database, only the password can be read from `database.external.existingSecret` (with the key hardcoded to `password`); `host`, `port`, `username` and `coreDatabase` must be plaintext values. This PR turns `existingSecret` into an object so the **whole** connection can come from one secret, with configurable key names:

```yaml
database:
  external:
    existingSecret:
      enabled: false
      name: "my-external-secret-name"
      keys:
        host: host
        port: port
        username: username
        password: password
        coreDatabase: dbName
```

- When `enabled: true`: `core` (deployment + pre-upgrade job) and `exporter` source `POSTGRESQL_HOST/PORT/USERNAME/PASSWORD/DATABASE` from the referenced secret via `secretKeyRef`, and `core-cm` / `core-secret` / `exporter-cm-env` / `exporter-secret` skip emitting the plaintext values.
- When `enabled: false`: behaviour is unchanged (backward compatible).

### Testing

- `helm lint` → 0 failed.
- `helm template` with `database.type=external` and `database.external.existingSecret.enabled=true` renders all five connection variables from the referenced secret on both core and exporter; with it disabled, the rendered output matches `main`.