### PR TITLE
Render external database connection values with tpl

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -89,7 +89,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- template "harbor.database" . }}
   {{- else -}}
-    {{- .Values.database.external.host -}}
+    {{- tpl (.Values.database.external.host | toString) $ -}}
   {{- end -}}
 {{- end -}}
 
@@ -97,7 +97,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- printf "%s" "5432" -}}
   {{- else -}}
-    {{- .Values.database.external.port -}}
+    {{- tpl (.Values.database.external.port | toString) $ -}}
   {{- end -}}
 {{- end -}}
 
@@ -105,7 +105,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- printf "%s" "postgres" -}}
   {{- else -}}
-    {{- .Values.database.external.username -}}
+    {{- tpl (.Values.database.external.username | toString) $ -}}
   {{- end -}}
 {{- end -}}
 
@@ -134,7 +134,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- printf "%s" "registry" -}}
   {{- else -}}
-    {{- .Values.database.external.coreDatabase -}}
+    {{- tpl (.Values.database.external.coreDatabase | toString) $ -}}
   {{- end -}}
 {{- end -}}
 
@@ -142,7 +142,7 @@ app: "{{ template "harbor.name" . }}"
   {{- if eq .Values.database.type "internal" -}}
     {{- printf "%s" "disable" -}}
   {{- else -}}
-    {{- .Values.database.external.sslmode -}}
+    {{- tpl (.Values.database.external.sslmode | toString) $ -}}
   {{- end -}}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -1103,6 +1103,8 @@ database:
       #    memory: 128Mi
       #    cpu: 100m
   external:
+    # host, port, username and coreDatabase are rendered with `tpl`, so they may
+    # contain template expressions, e.g. host: "{{ .Release.Name }}-postgresql".
     host: "192.168.0.1"
     port: "5432"
     username: "user"


### PR DESCRIPTION
Closes #2383.

### What
The external DB connection values (`database.external.host`, `port`, `username`, `coreDatabase`, `sslmode`) are emitted verbatim by the `harbor.database.*` helpers, so they cannot contain template expressions. This wraps the external branch of those helpers in `tpl`:

```
{{- tpl (.Values.database.external.host | toString) $ -}}
```

so values may reference the release context, e.g.:

```yaml
database:
  external:
    host: "{{ .Release.Name }}-postgresql-primary"
```

The `password` helper is intentionally left untouched.

### Why
Lets a parent/umbrella chart point Harbor at a release-scoped database service without hardcoding the release name — enabling multiple installs in one namespace.

### Compatibility
A value with no template syntax renders unchanged, so this is fully backward compatible.

### Testing
- `helm lint` → 0 failed.
- `helm template` with `database.type=external`:
  - `host: "{{ .Release.Name }}-postgresql-primary"` → `POSTGRESQL_HOST: "myrel-postgresql-primary"`
  - plain `host: "db.example.com"` → `POSTGRESQL_HOST: "db.example.com"` (unchanged)