### PR TITLE
fix: validate empty route parentRefs and omit empty hostnames

### DIFF
--- a/templates/gateway-apis/route.yaml
+++ b/templates/gateway-apis/route.yaml
@@ -22,10 +22,15 @@ metadata:
 {{ toYaml $route.annotations | indent 4 }}
 {{- end }}
 spec:
+  {{- if not $route.parentRefs }}
+    {{- fail "expose.route.parentRefs must be set when expose.type is \"route\": an HTTPRoute with no parentRefs attaches to no Gateway and cannot serve traffic." }}
+  {{- end }}
   parentRefs:
-  {{- toYaml $route.parentRefs | nindent 2 }}
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hosts }}
   hostnames:
-  {{- toYaml $route.hosts | nindent 2 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
   - matches:
     - path:

--- a/test/unittest/gateway-apis/route_test.yaml
+++ b/test/unittest/gateway-apis/route_test.yaml
@@ -94,3 +94,30 @@ tests:
       - equal:
           path: spec.rules[1].matches[0].path.value
           value: /
+
+  - it: Route fails with a clear message when parentRefs is empty
+    set:
+      expose:
+        type: route
+    template: templates/gateway-apis/route.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: 'expose.route.parentRefs must be set when expose.type is "route": an HTTPRoute with no parentRefs attaches to no Gateway and cannot serve traffic.'
+
+  - it: Route renders with parentRefs set but hosts left empty
+    set:
+      expose:
+        type: route
+        route:
+          parentRefs:
+            - name: test-parent
+              namespace: test-namespace
+    template: templates/gateway-apis/route.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: test-parent
+      - notExists:
+          path: spec.hostnames

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,8 @@ expose:
   route:
     labels: {}
     annotations: {}
-    # References to the parent gateways
+    # References to the parent gateways. Required when expose.type is "route":
+    # an HTTPRoute with no parentRefs attaches to no Gateway and cannot serve traffic.
     parentRefs: []
       # - name: envoy-internal
       #   namespace: networking


### PR DESCRIPTION
### Problem

When `expose.type: route` is used with the chart's own default values (`expose.route.parentRefs: []` and `expose.route.hosts: []`), `helm template` fails with:

    Error: YAML parse error on harbor/templates/gateway-apis/route.yaml: error converting YAML to JSON: yaml: line 9: could not find expected ':'

`toYaml` on an empty list returns the flow literal `[]`, and `nindent 2` put it at the same indentation as the parent `parentRefs:` / `hostnames:` key, so it parsed as a sibling node. `expose.type: route` was broken out of the box, with a cryptic error and no user override required.

Fixes #2385

### Fix

`parentRefs` and `hostnames` are treated differently, matching their roles in the Gateway API HTTPRoute spec:

- **`parentRefs`** — an HTTPRoute with no `parentRefs` attaches to no Gateway and cannot serve traffic, so it is effectively required in route mode. When it is empty the template now `fail`s with a clear message instead of emitting invalid YAML.
- **`hostnames`** — genuinely optional per the spec (omitting it matches all hostnames), so it is wrapped in a `{{- with }}` guard and omitted when the list is empty, rendered at `nindent 4` when present.

### Validation

- `helm template --set expose.type=route,expose.tls.enabled=false .` now fails with a clear `expose.route.parentRefs must be set …` message (previously a cryptic YAML parse error).
- With `parentRefs` set and `hosts` empty, `parentRefs` renders and `hostnames` is omitted.
- `helm unittest -f 'test/unittest/gateway-apis/*.yaml' .` passes (updated the empty-defaults case to assert the clear failure; added the parentRefs-set/hosts-empty case).
- `helm lint .` passes.
