### PR TITLE
feat: allow trivy github token to be read from existing secret

### DIFF
--- a/templates/trivy/trivy-secret.yaml
+++ b/templates/trivy/trivy-secret.yaml
@@ -9,5 +9,7 @@ metadata:
 type: Opaque
 data:
   redisURL: {{ include "harbor.redis.urlForTrivy" . | b64enc }}
+{{- if not .Values.trivy.gitHubTokenExistingSecret }}
   gitHubToken: {{  .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -92,8 +92,12 @@ spec:
             - name: "SCANNER_TRIVY_GITHUB_TOKEN"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "harbor.trivy" . }}
+                  name: {{ default (include "harbor.trivy" .) .Values.trivy.gitHubTokenExistingSecret }}
+                  {{- if .Values.trivy.gitHubTokenExistingSecret }}
+                  key: {{ .Values.trivy.gitHubTokenExistingSecretKey }}
+                  {{- else }}
                   key: gitHubToken
+                  {{- end }}
             - name: "SCANNER_TRIVY_SEVERITY"
               value: {{ .Values.trivy.severity | quote }}
             - name: "SCANNER_TRIVY_IGNORE_UNFIXED"

--- a/test/unittest/trivy/trivy_secret_test.yaml
+++ b/test/unittest/trivy/trivy_secret_test.yaml
@@ -1,0 +1,26 @@
+suite: TrivySecret
+
+tests:
+  - it: GitHubTokenInChartManagedSecret
+    set:
+      trivy:
+        enabled: true
+        gitHubToken: token123
+    template: templates/trivy/trivy-secret.yaml
+    asserts:
+      - equal:
+          path: data.gitHubToken
+          value: dG9rZW4xMjM=
+
+  - it: GitHubTokenOmittedWhenExistingSecretUsed
+    set:
+      trivy:
+        enabled: true
+        gitHubToken: token123
+        gitHubTokenExistingSecret: my-github-token
+    template: templates/trivy/trivy-secret.yaml
+    asserts:
+      - notExists:
+          path: data.gitHubToken
+      - exists:
+          path: data.redisURL

--- a/test/unittest/trivy/trivy_statefulset_test.yaml
+++ b/test/unittest/trivy/trivy_statefulset_test.yaml
@@ -96,6 +96,38 @@ tests:
       - notExists:
           path: spec.volumeClaimTemplates
   
+  - it: GitHubTokenFromChartManagedSecret
+    set:
+      trivy:
+        enabled: true
+    template: templates/trivy/trivy-sts.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "SCANNER_TRIVY_GITHUB_TOKEN"
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-harbor-trivy
+                key: gitHubToken
+
+  - it: GitHubTokenFromExistingSecret
+    set:
+      trivy:
+        enabled: true
+        gitHubTokenExistingSecret: my-github-token
+        gitHubTokenExistingSecretKey: token
+    template: templates/trivy/trivy-sts.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "SCANNER_TRIVY_GITHUB_TOKEN"
+            valueFrom:
+              secretKeyRef:
+                name: my-github-token
+                key: token
+
   - it: TrivyDBRepository
     set:
       trivy:

--- a/values.yaml
+++ b/values.yaml
@@ -1017,6 +1017,13 @@ trivy:
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
   gitHubToken: ""
+  # gitHubTokenExistingSecret the name of an existing secret to read the GitHub
+  # access token from, instead of storing it in the chart-managed secret via
+  # `gitHubToken`. When set, `gitHubToken` is ignored.
+  gitHubTokenExistingSecret: ""
+  # gitHubTokenExistingSecretKey the key within the existing secret that holds
+  # the GitHub access token. Only used when `gitHubTokenExistingSecret` is set.
+  gitHubTokenExistingSecretKey: "gitHubToken"
   # skipUpdate the flag to disable Trivy DB downloads from GitHub
   #
   # You might want to set the value of this flag to `true` in test or CI/CD environments to avoid GitHub rate limiting issues.


### PR DESCRIPTION
This pull requests allows the trivy github token to be retrieved from an existing secret. This eases rotation when using tools like external secrets